### PR TITLE
Fix incorrect object copy

### DIFF
--- a/pkg/controller/propagator/propagation.go
+++ b/pkg/controller/propagator/propagation.go
@@ -579,9 +579,7 @@ func (r *ReconcilePolicy) handleDecision(instance *policiesv1.Policy, decision a
 	if policyHasTemplates(instance) {
 		//template delimis detected, build a temp holder policy with templates resolved
 		//before doing a compare with the replicated policy in the cluster namespaces
-		tempResolvedPlc := &policiesv1.Policy{}
-		tempResolvedPlc.SetAnnotations(instance.GetAnnotations())
-		tempResolvedPlc.Spec = instance.Spec
+		tempResolvedPlc := instance.DeepCopy()
 		tmplErr := r.processTemplates(tempResolvedPlc, decision, instance)
 		if tmplErr != nil {
 			return tmplErr


### PR DESCRIPTION
Fixing a bug in my earlier PR  https://github.com/open-cluster-management/governance-policy-propagator/pull/88

Should be doing a copy of the object instead of just setting references to contents,  
this was causing changes to temp object to impact the original object leading to incorrect processing of templates in later iterations of the handleDecisions loop.   FYI @gparvin 



Signed-off-by: ckandag <ckandaga@redhat.com>

