### PR TITLE
Disable fromSecret on hub templates

### DIFF
--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -49,7 +49,11 @@ func Initialize(kubeconfig *rest.Config, kubeclient *kubernetes.Interface) {
 	kubeClient = kubeclient
 	// Adding four spaces to the indentation makes the usage of `indent N` be from the logical
 	// starting point of the resource object wrapped in the ConfigurationPolicy.
-	templateCfg = templates.Config{AdditionalIndentation: 8, StartDelim: "{{hub", StopDelim: "hub}}"}
+	templateCfg = templates.Config{
+		AdditionalIndentation: 8,
+		DisabledFunctions:     []string{"fromSecret"},
+		StartDelim:            "{{hub", StopDelim: "hub}}",
+	}
 
 	attempts = getEnvVarPosInt(attemptsEnvName, attemptsDefault)
 	requeueErrorDelay = getEnvVarPosInt(requeueErrorDelayEnvName, requeueErrorDelayDefault)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/open-cluster-management/api v0.0.0-20210527013639-a6845f2ebcb1
-	github.com/open-cluster-management/go-template-utils v1.2.3
+	github.com/open-cluster-management/go-template-utils v1.3.0
 	github.com/open-cluster-management/multicloud-operators-placementrule v1.2.4-0-20210816-699e5
 	github.com/prometheus/client_golang v1.11.0
 	k8s.io/api v0.21.3

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/open-cluster-management/api v0.0.0-20200903203421-64b667f5455c/go.mod
 github.com/open-cluster-management/api v0.0.0-20210513122330-d76f10481f05/go.mod h1:ot+A1DWq+v1IV+e1S7nhIteYAmNByFgtazvzpoeAfRQ=
 github.com/open-cluster-management/api v0.0.0-20210527013639-a6845f2ebcb1 h1:AaFycHD9YOfFXe9C5VsYxKf4LKCXKSLZgK2DnFdHY4M=
 github.com/open-cluster-management/api v0.0.0-20210527013639-a6845f2ebcb1/go.mod h1:ot+A1DWq+v1IV+e1S7nhIteYAmNByFgtazvzpoeAfRQ=
-github.com/open-cluster-management/go-template-utils v1.2.3 h1:eeSayCDXV0IJAJjr083yuIY95NSQmQSIgTqeJ44GO2g=
-github.com/open-cluster-management/go-template-utils v1.2.3/go.mod h1:+D8buOYN/VMVuTEd8WnnJQn+Z1oU4sT2OXbYZE+mIDk=
+github.com/open-cluster-management/go-template-utils v1.3.0 h1:AQ7pIWyBaXArFoIrouv06U2GRC9YSpXEZaqfpJ6hJNE=
+github.com/open-cluster-management/go-template-utils v1.3.0/go.mod h1:+D8buOYN/VMVuTEd8WnnJQn+Z1oU4sT2OXbYZE+mIDk=
 github.com/open-cluster-management/klusterlet-addon-controller v0.0.0-20210303215539-1d12cebe6f19/go.mod h1:YWcjLe+zqmdqPFvwzASizCa8JdXe5briBgxoP+r3CRM=
 github.com/open-cluster-management/library-e2e-go v0.0.0-20200620112055-c80fc3c14997/go.mod h1:glvUOJg5EAb1Lq0OPcYhl57PJTxN2T5xuSfdV3Iab4Y=
 github.com/open-cluster-management/library-go v0.0.0-20200828173847-299c21e6c3fc/go.mod h1:X9KdKajEnrx6+LQSjo+61gLdk4Ntmwp+YEYD0CIJT7I=

--- a/test/resources/case9_templates/case9-test-policy.yaml
+++ b/test/resources/case9_templates/case9-test-policy.yaml
@@ -31,9 +31,9 @@ spec:
                   Vlanid: |
                     '{{hub printf "%s-vlanid" .ManagedClusterName | fromConfigMap "policy-propagator-test" "case9-config"  | toInt hub}}'
                   indent-test: |
-                    {{hub fromSecret "policy-propagator-test" "case9-secret" "saying" | base64dec | indent 4 hub}}
+                    {{hub fromConfigMap "policy-propagator-test" "case9-config2" "saying" | base64dec | indent 4 hub}}
                   autoindent-test: |
-                    {{hub fromSecret "policy-propagator-test" "case9-secret" "saying" | base64dec | autoindent hub}}
+                    {{hub fromConfigMap "policy-propagator-test" "case9-config2" "saying" | base64dec | autoindent hub}}
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -69,8 +69,8 @@ data:
   managed2-vlanid: "456"
 ---
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
-  name: case9-secret
+  name: case9-config2
 data:
   saying: RG8uCk9yIGRvIG5vdC4KVGhlcmUgaXMgbm8gdHJ5Lgo=


### PR DESCRIPTION
This is to discourage storing sensitive information directly in a policy
due to concerns with the lack of etcd encryption on Policy objects.