### PR TITLE
Refactor and add additional logging

### DIFF
--- a/controllers/policymetrics/policymetrics_controller.go
+++ b/controllers/policymetrics/policymetrics_controller.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/api/v1"
@@ -22,7 +21,7 @@ import (
 
 const ControllerName string = "policy-metrics"
 
-var log = logf.Log.WithName(ControllerName)
+var log = ctrl.Log.WithName(ControllerName)
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *MetricReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -48,8 +47,8 @@ type MetricReconciler struct {
 // Reconcile reads the state of the cluster for the Policy object and ensures that the exported
 // policy metrics are accurate, updating them as necessary.
 func (r *MetricReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling metric for Policy...")
+	log := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	log.Info("Reconciling metric for the policy")
 
 	// Need to know if the policy is a root policy to create the correct prometheus labels
 	// Can't try to use a label on the policy, because the policy might have been deleted.
@@ -57,7 +56,7 @@ func (r *MetricReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 
 	err := r.List(ctx, clusterList, &client.ListOptions{})
 	if err != nil {
-		reqLogger.Error(err, "Failed to list clusters, going to retry...")
+		log.Error(err, "Failed to list clusters, going to requeue the request")
 
 		return reconcile.Result{}, err
 	}
@@ -70,7 +69,7 @@ func (r *MetricReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		splitName := strings.SplitN(request.Name, ".", 2)
 		if len(splitName) < 2 {
 			// Don't do any metrics if the policy is invalid.
-			reqLogger.Info("Invalid policy in cluster namespace: missing root policy ns prefix")
+			log.Info("Invalid policy in cluster namespace: missing root policy ns prefix")
 
 			return reconcile.Result{}, nil
 		}
@@ -97,33 +96,31 @@ func (r *MetricReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		if errors.IsNotFound(err) {
 			// Try to delete the gauge, but don't get hung up on errors. Log whether it was deleted.
 			statusGaugeDeleted := policyStatusGauge.Delete(promLabels)
-			reqLogger.Info("Policy not found - must have been deleted.",
-				"status-gauge-deleted", statusGaugeDeleted)
+			log.Info("Policy not found. It must have been deleted.", "status-gauge-deleted", statusGaugeDeleted)
 
 			return reconcile.Result{}, nil
 		}
 
-		reqLogger.Error(err, "Failed to get Policy")
+		log.Error(err, "Failed to get Policy")
 
 		return reconcile.Result{}, err
 	}
 
-	reqLogger.Info("Got active state", "pol.Spec.Disabled", pol.Spec.Disabled)
+	log.V(2).Info("Got active state", "pol.Spec.Disabled", pol.Spec.Disabled)
 
 	if pol.Spec.Disabled {
 		// The policy is no longer active, so delete its metric
 		statusGaugeDeleted := policyStatusGauge.Delete(promLabels)
-		reqLogger.Info("Metric removed for non-active policy",
-			"status-gauge-deleted", statusGaugeDeleted)
+		log.V(1).Info("Metric removed for non-active policy", "status-gauge-deleted", statusGaugeDeleted)
 
 		return reconcile.Result{}, nil
 	}
 
-	reqLogger.Info("Got ComplianceState", "pol.Status.ComplianceState", pol.Status.ComplianceState)
+	log.V(2).Info("Got ComplianceState", "pol.Status.ComplianceState", pol.Status.ComplianceState)
 
 	statusMetric, err := policyStatusGauge.GetMetricWith(promLabels)
 	if err != nil {
-		reqLogger.Error(err, "Failed to get status metric from GaugeVec")
+		log.Error(err, "Failed to get status metric from GaugeVec")
 
 		return reconcile.Result{}, err
 	}

--- a/controllers/propagator/placementBindingMapper.go
+++ b/controllers/propagator/placementBindingMapper.go
@@ -18,11 +18,14 @@ func placementBindingMapper(c client.Client) handler.MapFunc {
 		object := obj.(*policiesv1.PlacementBinding)
 		var result []reconcile.Request
 
+		log := log.WithValues("name", object.GetName(), "namespace", object.GetNamespace())
+
+		log.V(2).Info("Reconcile request for a PlacementBinding")
+
 		subjects := object.Subjects
 		for _, subject := range subjects {
 			if subject.APIGroup == policiesv1.SchemeGroupVersion.Group && subject.Kind == policiesv1.Kind {
-				log.Info("Found reconciliation request from placement binding...",
-					"Namespace", object.GetNamespace(), "Name", object.GetName(), "Policy-Name", subject.Name)
+				log.V(2).Info("Found reconciliation request from placement binding", "policyName", subject.Name)
 
 				request := reconcile.Request{NamespacedName: types.NamespacedName{
 					Name:      subject.Name,

--- a/controllers/propagator/placementDecisionMapper.go
+++ b/controllers/propagator/placementDecisionMapper.go
@@ -17,7 +17,9 @@ import (
 
 func placementDecisionMapper(c client.Client) handler.MapFunc {
 	return func(object client.Object) []reconcile.Request {
-		log.Info("Reconcile Request for PlacementDecision %s in namespace %s", object.GetName(), object.GetNamespace())
+		log := log.WithValues("name", object.GetName(), "namespace", object.GetNamespace())
+
+		log.V(2).Info("Reconcile request for a placement decision")
 
 		// get the placement name from the placementdecision
 		placementName := object.GetLabels()["cluster.open-cluster-management.io/placement"]
@@ -51,8 +53,7 @@ func placementDecisionMapper(c client.Client) handler.MapFunc {
 					continue
 				}
 
-				log.Info("Found reconciliation request from placement decision...", "Namespace", object.GetNamespace(),
-					"Name", object.GetName(), "Policy-Name", subject.Name)
+				log.V(2).Info("Found reconciliation request from a placement decision", "policyName", subject.Name)
 
 				// generate reconcile request for policy referenced by pb
 				request := reconcile.Request{NamespacedName: types.NamespacedName{

--- a/controllers/propagator/placementRuleMapper.go
+++ b/controllers/propagator/placementRuleMapper.go
@@ -17,7 +17,10 @@ import (
 
 func placementRuleMapper(c client.Client) handler.MapFunc {
 	return func(object client.Object) []reconcile.Request {
-		log.Info("Reconcile Request for PlacementRule", "Name", object.GetName(), "Namespace", object.GetNamespace())
+		log := log.WithValues("name", object.GetName(), "namespace", object.GetNamespace())
+
+		log.V(2).Info("Reconcile Request for PlacementRule")
+
 		// list pb
 		pbList := &policiesv1.PlacementBindingList{}
 
@@ -37,15 +40,7 @@ func placementRuleMapper(c client.Client) handler.MapFunc {
 				subjects := pb.Subjects
 				for _, subject := range subjects {
 					if subject.APIGroup == policiesv1.SchemeGroupVersion.Group && subject.Kind == policiesv1.Kind {
-						log.Info(
-							"Found reconciliation request from placement rule...",
-							"Namespace",
-							object.GetNamespace(),
-							"Name",
-							object.GetName(),
-							"Policy-Name",
-							subject.Name,
-						)
+						log.V(1).Info("Found reconciliation request from placement rule", "policyName", subject.Name)
 						// generate reconcile request for policy referenced by pb
 						request := reconcile.Request{NamespacedName: types.NamespacedName{
 							Name:      subject.Name,

--- a/controllers/propagator/policyMapper.go
+++ b/controllers/propagator/policyMapper.go
@@ -18,21 +18,23 @@ import (
 // owners of object from label: policy.open-cluster-management.io/root-policy
 func policyMapper(c client.Client) handler.MapFunc {
 	return func(object client.Object) []reconcile.Request {
+		log := log.WithValues("name", object.GetName(), "namespace", object.GetNamespace())
+
+		log.V(2).Info("Reconcile request for a policy")
+
 		rootPlcName := object.GetLabels()[common.RootPolicyLabel]
 		var name string
 		var namespace string
 
 		if rootPlcName != "" {
 			// policy.open-cluster-management.io/root-policy exists, should be a replicated policy
-			log.Info("Found reconciliation request from replicated policy...", "Namespace", object.GetNamespace(),
-				"Name", object.GetName())
+			log.V(2).Info("Found reconciliation request from replicated policy")
 
 			name = strings.Split(rootPlcName, ".")[1]
 			namespace = strings.Split(rootPlcName, ".")[0]
 		} else {
 			// policy.open-cluster-management.io/root-policy doesn't exist, should be a root policy
-			log.Info("Found reconciliation request from root policy...", "Namespace", object.GetNamespace(),
-				"Name", object.GetName())
+			log.V(2).Info("Found reconciliation request from root policy")
 
 			name = object.GetName()
 			namespace = object.GetNamespace()


### PR DESCRIPTION
This converts all logging to use the zap logging library. It also
refactors the existing log messages to be structured and have different
verbosity. The messages were also changed to have a more consistent
style. Lastly, log messages are added in places where they were
missing.

Resolves:
https://github.com/open-cluster-management/backlog/issues/18025