### PR TITLE
Generate encryption keys for each managed cluster

### DIFF
--- a/controllers/propagator/encryption.go
+++ b/controllers/propagator/encryption.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package propagator
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// EncryptionKeyCache acts as a cache for encryption keys for each managed cluster for policy template encryption.
+// This abstracts locking and unlocking operations to account for concurrency.
+type EncryptionKeyCache struct {
+	cache map[string][]byte
+	mutex sync.RWMutex
+}
+
+// Get will return the key for the managed cluster in the cache. If it's not set, a nil value is returned.
+func (c *EncryptionKeyCache) Get(clusterName string) []byte {
+	c.mutex.RLock()
+
+	key := c.cache[clusterName]
+
+	c.mutex.RUnlock()
+
+	return key
+}
+
+// Set will store the key for the managed cluster in the cache.
+func (c *EncryptionKeyCache) Set(clusterName string, key []byte) {
+	c.mutex.Lock()
+
+	// Initialize the map if it's nil.
+	if c.cache == nil {
+		c.cache = map[string][]byte{}
+	}
+
+	c.cache[clusterName] = key
+
+	c.mutex.Unlock()
+}
+
+// getEncryptionKey will get the encryption key for a managed cluster used for policy template encryption. If it doesn't
+// already exist as a secret on the Hub cluster, it will be generated. All retrieved keys are cached.
+func (r *PolicyReconciler) getEncryptionKey(clusterName string) ([]byte, error) {
+	const secretName = "policy-encryption-key"
+
+	key := r.encryptionKeyCache.Get(clusterName)
+	if key != nil {
+		log.V(2).Info("Using the cached encryption key", "cluster", clusterName)
+
+		return key, nil
+	}
+
+	ctx := context.TODO()
+	objectKey := types.NamespacedName{
+		Name:      secretName,
+		Namespace: clusterName,
+	}
+	encryptionSecret := &corev1.Secret{}
+
+	err := r.Get(ctx, objectKey, encryptionSecret)
+	if k8serrors.IsNotFound(err) {
+		const keySize = 256
+
+		log.V(1).Info(
+			"Generating an encryption key for policy templates that will be stored in a secret",
+			"cluster", clusterName,
+			"name", secretName,
+			"namespace", clusterName,
+		)
+
+		key := make([]byte, keySize/8)
+		if _, err := rand.Read(key); err != nil {
+			return nil, fmt.Errorf("failed to generate an AES-256 key: %w", err)
+		}
+
+		encryptionSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: clusterName,
+				// This is required for disaster recovery.
+				Labels: map[string]string{"cluster.open-cluster-management.io/backup": "policy"},
+			},
+			Data: map[string][]byte{
+				"key": key,
+			},
+		}
+
+		err = r.Create(ctx, encryptionSecret)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create the Secret %s/%s: %w", clusterName, secretName, err)
+		}
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to get the Secret %s/%s: %w", clusterName, secretName, err)
+	}
+
+	key = encryptionSecret.Data["key"]
+	r.encryptionKeyCache.Set(clusterName, key)
+
+	return key, nil
+}

--- a/controllers/propagator/encryption_test.go
+++ b/controllers/propagator/encryption_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package propagator
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	clusterName = "local-cluster"
+	keySize     = 256
+	secretName  = "policy-encryption-key"
+)
+
+func TestEncryptionKeyCache(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	cache := EncryptionKeyCache{}
+
+	cache.Set(clusterName, []byte{byte('A')})
+	value := cache.Get(clusterName)
+	Expect(value).To(Equal([]byte{byte('A')}))
+}
+
+func TestGetEncryptionKeyNoSecret(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	client := fake.NewClientBuilder().Build()
+	r := PolicyReconciler{Client: client}
+	key, err := r.getEncryptionKey(clusterName)
+
+	Expect(err).To(BeNil())
+	// Verify that the generated key is 256 bits.
+	Expect(len(key)).To(Equal(keySize / 8))
+
+	ctx := context.TODO()
+	objectKey := types.NamespacedName{
+		Name:      secretName,
+		Namespace: clusterName,
+	}
+	encryptionSecret := &corev1.Secret{}
+	err = client.Get(ctx, objectKey, encryptionSecret)
+
+	Expect(err).To(BeNil())
+	// Verify that the generated key stored in the secret is 256 bits.
+	Expect(len(encryptionSecret.Data["key"])).To(Equal(keySize / 8))
+
+	// Check that the value is cached.
+	Expect(len(r.encryptionKeyCache.cache[clusterName])).To(Equal(keySize / 8))
+}
+
+func TestGetEncryptionKeySecretExists(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	// Generate an AES-256 key and stored it as a secret.
+	key := make([]byte, keySize/8)
+	_, err := rand.Read(key)
+	Expect(err).To(BeNil())
+
+	encryptionSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: clusterName,
+		},
+		Data: map[string][]byte{
+			"key": key,
+		},
+	}
+
+	client := fake.NewClientBuilder().WithObjects(encryptionSecret).Build()
+
+	r := PolicyReconciler{Client: client}
+	key, err = r.getEncryptionKey(clusterName)
+
+	Expect(err).To(BeNil())
+	// Verify that the returned key is 256 bits.
+	Expect(len(key)).To(Equal(keySize / 8))
+
+	// Check that the value is cached.
+	Expect(len(r.encryptionKeyCache.cache[clusterName])).To(Equal(keySize / 8))
+}
+
+func TestGetEncryptionKeyCached(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	client := fake.NewClientBuilder().Build()
+
+	r := PolicyReconciler{Client: client}
+	r.encryptionKeyCache.cache = map[string][]byte{clusterName: {byte('A')}}
+
+	key, err := r.getEncryptionKey(clusterName)
+
+	Expect(err).To(BeNil())
+	Expect(string(key[0])).To(Equal("A"))
+}

--- a/controllers/propagator/policy_controller.go
+++ b/controllers/propagator/policy_controller.go
@@ -72,8 +72,9 @@ var _ reconcile.Reconciler = &PolicyReconciler{}
 // PolicyReconciler reconciles a Policy object
 type PolicyReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	encryptionKeyCache EncryptionKeyCache
+	Scheme             *runtime.Scheme
+	Recorder           record.EventRecorder
 }
 
 // Reconcile reads that state of the cluster for a Policy object and makes changes based on the state read

--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -835,6 +835,13 @@ func (r *PolicyReconciler) processTemplates(
 		replicatedPlc.SetAnnotations(annotations)
 	}
 
+	// For now, get/generate the key but the integration will occur in a future commit.
+	// See https://github.com/stolostron/backlog/issues/18712
+	_, err := r.getEncryptionKey(decision.ClusterName)
+	if err != nil {
+		return err
+	}
+
 	templateCfg := getTemplateCfg()
 	templateCfg.LookupNamespace = rootPlc.GetNamespace()
 


### PR DESCRIPTION
If a policy has Hub policy templates, an AES-256 key will be generated
for each managed cluster that the policy targets. The key is stored in
the `policy-encryption-key` secret in the managed cluster namespace.

Resolves:
https://github.com/stolostron/backlog/issues/18706