### PR TITLE
Allow offline builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ test-dependencies:
 # build section
 ############################################################
 
-build: fmt
+build:
 	@build/common/scripts/gobuild.sh build/_output/bin/$(IMG) main.go
 
 local: generate fmt


### PR DESCRIPTION
The build target called the fmt target which downloaded formatting
tools. This caused offline builds to fail.

Resolves:
https://github.com/stolostron/backlog/issues/19094