### PR TITLE
pb.subjects shouldn't be limited to 1

### DIFF
--- a/api/v1/placementbinding_types.go
+++ b/api/v1/placementbinding_types.go
@@ -52,7 +52,6 @@ type PlacementBinding struct {
 	// +kubebuilder:validation:Required
 	PlacementRef PlacementSubject `json:"placementRef"`
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MaxItems=1
 	// +kubebuilder:validation:MinItems=1
 	Subjects []Subject              `json:"subjects"`
 	Status   PlacementBindingStatus `json:"status,omitempty"`

--- a/deploy/crds/policy.open-cluster-management.io_placementbindings.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_placementbindings.yaml
@@ -83,7 +83,6 @@ spec:
               - kind
               - name
               type: object
-            maxItems: 1
             minItems: 1
             type: array
         required:


### PR DESCRIPTION
This reverts chnage in commit b7fd147
which restricts subjects to max 1 as it breaks the use case where one
placementbinding is used to binding multiple policies.
Signed-off-by: Yu Cao <ycao@redhat.com>