### PR TITLE
Support policy propagation through policyset

### DIFF
--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -25,3 +25,6 @@ var (
 
 // Kind Policy
 const Kind = "Policy"
+
+// PolicySetKind Policy
+const PolicySetKind = "PolicySet"

--- a/api/v1/placementbinding_types.go
+++ b/api/v1/placementbinding_types.go
@@ -15,7 +15,7 @@ type Subject struct {
 	APIGroup string `json:"apiGroup"`
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Enum=Policy
+	// +kubebuilder:validation:Enum=Policy;PolicySet
 	Kind string `json:"kind"`
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1

--- a/api/v1/policy_types.go
+++ b/api/v1/policy_types.go
@@ -57,6 +57,7 @@ type Placement struct {
 	PlacementRule    string                     `json:"placementRule,omitempty"`
 	Placement        string                     `json:"placement,omitempty"`
 	Decisions        []appsv1.PlacementDecision `json:"decisions,omitempty"`
+	PolicySet        string                     `json:"policySet,omitempty"`
 }
 
 // CompliancePerClusterStatus defines compliance per cluster status

--- a/api/v1/policyset_types.go
+++ b/api/v1/policyset_types.go
@@ -49,9 +49,12 @@ type PolicySetStatusResult struct {
 	Message   string                   `json:"message,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:path=policysets,scope=Namespaced
+// +kubebuilder:resource:path=policysets,shortName=plcset
+// +kubebuilder:printcolumn:name="Compliance state",type="string",JSONPath=".status.compliant"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // PolicySet is the Schema for the policysets API
 type PolicySet struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -64,6 +64,22 @@ func IsPbForPoicy(pb *policiesv1.PlacementBinding) bool {
 	return found
 }
 
+// IsPbForPoicySet compares group and kind with policyset group and kind for given pb
+func IsPbForPoicySet(pb *policiesv1.PlacementBinding) bool {
+	found := false
+
+	subjects := pb.Subjects
+	for _, subject := range subjects {
+		if subject.Kind == policiesv1.PolicySetKind && subject.APIGroup == policiesv1.SchemeGroupVersion.Group {
+			found = true
+
+			break
+		}
+	}
+
+	return found
+}
+
 // FindNonCompliantClustersForPolicy returns cluster in noncompliant status with given policy
 func FindNonCompliantClustersForPolicy(plc *policiesv1.Policy) []string {
 	clusterList := []string{}

--- a/controllers/propagator/placementBindingPredicate.go
+++ b/controllers/propagator/placementBindingPredicate.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stolostron/governance-policy-propagator/controllers/common"
 )
 
-// we only want to watch for pb contains policy as subjects
+// we only want to watch for pb contains policy and policyset as subjects
 var pbPredicateFuncs = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		// nolint: forcetypeassert
@@ -19,18 +19,19 @@ var pbPredicateFuncs = predicate.Funcs{
 		// nolint: forcetypeassert
 		pbObjOld := e.ObjectOld.(*policiesv1.PlacementBinding)
 
-		return common.IsPbForPoicy(pbObjNew) || common.IsPbForPoicy(pbObjOld)
+		return common.IsPbForPoicy(pbObjNew) || common.IsPbForPoicy(pbObjOld) ||
+			common.IsPbForPoicySet(pbObjNew) || common.IsPbForPoicySet(pbObjOld)
 	},
 	CreateFunc: func(e event.CreateEvent) bool {
 		// nolint: forcetypeassert
 		pbObj := e.Object.(*policiesv1.PlacementBinding)
 
-		return common.IsPbForPoicy(pbObj)
+		return common.IsPbForPoicy(pbObj) || common.IsPbForPoicySet(pbObj)
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool {
 		// nolint: forcetypeassert
 		pbObj := e.Object.(*policiesv1.PlacementBinding)
 
-		return common.IsPbForPoicy(pbObj)
+		return common.IsPbForPoicy(pbObj) || common.IsPbForPoicySet(pbObj)
 	},
 }

--- a/controllers/propagator/placementRuleMapper.go
+++ b/controllers/propagator/placementRuleMapper.go
@@ -17,7 +17,7 @@ import (
 
 func placementRuleMapper(c client.Client) handler.MapFunc {
 	return func(object client.Object) []reconcile.Request {
-		log := log.WithValues("name", object.GetName(), "namespace", object.GetNamespace())
+		log := log.WithValues("placementRuleName", object.GetName(), "namespace", object.GetNamespace())
 
 		log.V(2).Info("Reconcile Request for PlacementRule")
 
@@ -39,14 +39,37 @@ func placementRuleMapper(c client.Client) handler.MapFunc {
 				// check if it is for policy
 				subjects := pb.Subjects
 				for _, subject := range subjects {
-					if subject.APIGroup == policiesv1.SchemeGroupVersion.Group && subject.Kind == policiesv1.Kind {
-						log.V(1).Info("Found reconciliation request from placement rule", "policyName", subject.Name)
-						// generate reconcile request for policy referenced by pb
-						request := reconcile.Request{NamespacedName: types.NamespacedName{
-							Name:      subject.Name,
-							Namespace: object.GetNamespace(),
-						}}
-						result = append(result, request)
+					if subject.APIGroup == policiesv1.SchemeGroupVersion.Group {
+						if subject.Kind == policiesv1.Kind {
+							log.V(2).Info("Found reconciliation request from policy placement rule", "policyName",
+								subject.Name)
+							// generate reconcile request for policy referenced by pb
+							request := reconcile.Request{NamespacedName: types.NamespacedName{
+								Name:      subject.Name,
+								Namespace: object.GetNamespace(),
+							}}
+							result = append(result, request)
+						} else if subject.Kind == policiesv1.PolicySetKind {
+							policySetNamespacedName := types.NamespacedName{
+								Name:      subject.Name,
+								Namespace: object.GetNamespace(),
+							}
+							policySet := &policiesv1.PolicySet{}
+							err := c.Get(context.TODO(), policySetNamespacedName, policySet)
+							if err != nil {
+								return nil
+							}
+							policies := policySet.Spec.Policies
+							for _, plc := range policies {
+								log.V(2).Info("Found reconciliation request from a policyset placement rule",
+									"policySetName", subject.Name, "policyName", string(plc))
+								request := reconcile.Request{NamespacedName: types.NamespacedName{
+									Name:      string(plc),
+									Namespace: object.GetNamespace(),
+								}}
+								result = append(result, request)
+							}
+						}
 					}
 				}
 			}

--- a/controllers/propagator/policySetMapper.go
+++ b/controllers/propagator/policySetMapper.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package propagator
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+)
+
+func policySetMapper(c client.Client) handler.MapFunc {
+	return func(object client.Object) []reconcile.Request {
+		log := log.WithValues("policySetName", object.GetName(), "namespace", object.GetNamespace())
+		log.V(2).Info("Reconcile Request for PolicySet")
+
+		var result []reconcile.Request
+
+		for _, plc := range object.(*policiesv1.PolicySet).Spec.Policies {
+			log.V(2).Info("Found reconciliation request from a policyset", "policyName", string(plc))
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{
+				Name:      string(plc),
+				Namespace: object.GetNamespace(),
+			}}
+			result = append(result, request)
+		}
+
+		return result
+	}
+}

--- a/controllers/propagator/policySetPredicate.go
+++ b/controllers/propagator/policySetPredicate.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package propagator
+
+import (
+	"k8s.io/apimachinery/pkg/api/equality"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+)
+
+// we only want to watch for policyset objects with Spec.Policies field change
+var policySetPredicateFuncs = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		// nolint: forcetypeassert
+		policySetObjNew := e.ObjectNew.(*policiesv1.PolicySet)
+		// nolint: forcetypeassert
+		policySetObjOld := e.ObjectOld.(*policiesv1.PolicySet)
+
+		return !equality.Semantic.DeepEqual(policySetObjNew.Spec.Policies, policySetObjOld.Spec.Policies)
+	},
+	CreateFunc: func(e event.CreateEvent) bool {
+		return true
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return true
+	},
+}

--- a/controllers/propagator/policy_controller.go
+++ b/controllers/propagator/policy_controller.go
@@ -34,6 +34,7 @@ var log = ctrl.Log.WithName(ControllerName)
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies/finalizers,verbs=update
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=placementbindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policysets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters;placementdecisions;placements,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apps.open-cluster-management.io,resources=placementrules,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
@@ -53,6 +54,10 @@ func (r *PolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&source.Kind{Type: &policiesv1.Policy{}},
 			&common.EnqueueRequestsFromMapFunc{ToRequests: policyMapper(mgr.GetClient())}).
+		Watches(
+			&source.Kind{Type: &policiesv1.PolicySet{}},
+			&common.EnqueueRequestsFromMapFunc{ToRequests: policySetMapper(mgr.GetClient())},
+			builder.WithPredicates(policySetPredicateFuncs)).
 		Watches(
 			&source.Kind{Type: &policiesv1.PlacementBinding{}},
 			handler.EnqueueRequestsFromMapFunc(placementBindingMapper(mgr.GetClient())),

--- a/deploy/crds/policy.open-cluster-management.io_placementbindings.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_placementbindings.yaml
@@ -73,6 +73,7 @@ spec:
                 kind:
                   enum:
                   - Policy
+                  - PolicySet
                   minLength: 1
                   type: string
                 name:

--- a/deploy/crds/policy.open-cluster-management.io_policies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_policies.yaml
@@ -129,6 +129,8 @@ spec:
                       type: string
                     placementRule:
                       type: string
+                    policySet:
+                      type: string
                   type: object
                 type: array
               status:

--- a/deploy/crds/policy.open-cluster-management.io_policysets.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_policysets.yaml
@@ -13,10 +13,19 @@ spec:
     kind: PolicySet
     listKind: PolicySetList
     plural: policysets
+    shortNames:
+    - plcset
     singular: policyset
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.compliant
+      name: Compliance state
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: PolicySet is the Schema for the policysets API

--- a/test/e2e/case10_policyset_propagation_test.go
+++ b/test/e2e/case10_policyset_propagation_test.go
@@ -1,0 +1,687 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stolostron/governance-policy-propagator/controllers/common"
+	"github.com/stolostron/governance-policy-propagator/test/utils"
+)
+
+const (
+	path                               string = "../resources/case10_policyset_propagation/"
+	case10PolicyName                   string = "case10-test-policy"
+	case10PolicySetName                string = "case10-test-policyset"
+	case10PolicySetYaml                string = path + "case10-test-policyset.yaml"
+	case10PolicySetPlacementYaml       string = path + "case10-test-policyset-placement.yaml"
+	case10PolicySetPolicyYaml          string = path + "case10-test-policyset-policy.yaml"
+	case10PolicySetPolicyPlacementYaml string = path + "case10-test-policyset-policy-placement.yaml"
+)
+
+var _ = Describe("Test policyset propagation", func() {
+	Describe("Test policy propagation through policyset placementbinding with placementrule", func() {
+		It("should be created in user ns", func() {
+			By("Creating " + case10PolicySetYaml)
+			_, err := utils.KubectlWithOutput("apply",
+				"-f", case10PolicySetYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).NotTo(BeNil())
+		})
+		It("should propagate to cluster ns managed1", func() {
+			By("Patching test-policy-plr with decision of cluster managed1")
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case10PolicySetName+"-plr", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plr.Object["status"] = utils.GeneratePlrStatus("managed1")
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
+		})
+		It("should propagate to cluster ns managed2", func() {
+			By("Patching test-policy-plr with decision of cluster managed2")
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case10PolicySetName+"-plr", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plr.Object["status"] = utils.GeneratePlrStatus("managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed2", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
+		})
+		It("should propagate to cluster ns managed1 and managed2", func() {
+			By("Patching test-policy-plr with decision of both managed1 and managed2")
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case10PolicySetName+"-plr", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
+		})
+		It("should propagate to cluster ns managed1", func() {
+			By("Patching test-policy-plr with decision of cluster managed1")
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case10PolicySetName+"-plr", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plr.Object["status"] = utils.GeneratePlrStatus("managed1")
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPolicy,
+				testNamespace+"."+case10PolicyName,
+				"managed1",
+				true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			plc = utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPolicy,
+				testNamespace+"."+case10PolicyName,
+				"managed2",
+				false,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
+		})
+		It("should propagate to cluster ns managed1 and managed2", func() {
+			By("Patching test-policy-plr with decision of both managed1 and managed2")
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case10PolicySetName+"-plr", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
+		})
+		It("should remove policy from ns managed1 and managed2", func() {
+			By("Deleting policyset")
+			_, err := utils.KubectlWithOutput("delete", "policyset", case10PolicySetName, "-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, false, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		})
+		It("should be created in user ns", func() {
+			By("Creating " + case10PolicySetYaml)
+			_, err := utils.KubectlWithOutput("apply",
+				"-f", case10PolicySetYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).NotTo(BeNil())
+		})
+		It("should propagate to cluster ns managed1 and managed2", func() {
+			By("Patching test-policy-plr with decision of both managed1 and managed2")
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case10PolicySetName+"-plr", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
+		})
+		It("should remove policy from ns managed1 and managed2", func() {
+			By("Deleting placementbinding")
+			_, err := utils.KubectlWithOutput("delete", "PlacementBinding", case10PolicySetName+"-pb", "-n",
+				testNamespace)
+			Expect(err).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		})
+		It("should be created in user ns", func() {
+			By("Creating " + case10PolicySetYaml)
+			_, err := utils.KubectlWithOutput("apply",
+				"-f", case10PolicySetYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).NotTo(BeNil())
+		})
+		It("should propagate to cluster ns managed1 and managed2", func() {
+			By("Patching test-policy-plr with decision of both managed1 and managed2")
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case10PolicySetName+"-plr", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
+		})
+		It("should remove policy from ns managed1 and managed2", func() {
+			By("Deleting placementrule")
+			_, err := utils.KubectlWithOutput("delete", "PlacementRule", case10PolicySetName+"-plr", "-n",
+				testNamespace)
+			Expect(err).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		})
+		It("should be created in user ns", func() {
+			By("Creating " + case10PolicySetYaml)
+			_, err := utils.KubectlWithOutput("apply",
+				"-f", case10PolicySetYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).NotTo(BeNil())
+		})
+		It("should propagate to cluster ns managed1 and managed2", func() {
+			By("Patching test-policy-plr with decision of both managed1 and managed2")
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case10PolicySetName+"-plr", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plr.Object["status"] = utils.GeneratePlrStatus("managed1", "managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
+		})
+		It("should clean up", func() {
+			By("Deleting " + case10PolicySetYaml)
+			_, err := utils.KubectlWithOutput("delete",
+				"-f", case10PolicySetYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, false, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		})
+	})
+
+	Describe("Test policy propagation through both policy and policyset placementbinding with placementrule", func() {
+		It("should be created in user ns", func() {
+			By("Creating " + case10PolicySetYaml)
+			_, err := utils.KubectlWithOutput("apply",
+				"-f", case10PolicySetPolicyYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).NotTo(BeNil())
+		})
+		It("should propagate to cluster ns managed1", func() {
+			By("Patching " + case10PolicySetName + "-plr with decision of cluster managed1")
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case10PolicySetName+"-plr", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plr.Object["status"] = utils.GeneratePlrStatus("managed1")
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
+		})
+		It("should propagate to cluster ns managed1 and managed2", func() {
+			By("Patching " + case10PolicyName + "-plr with decision of cluster managed1")
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case10PolicyName+"-plr", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plr.Object["status"] = utils.GeneratePlrStatus("managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			plc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed2", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
+		})
+		It("should propagate to cluster ns managed1", func() {
+			By("Patching " + case10PolicyName + "-plr with decision of cluster managed1")
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case10PolicyName+"-plr", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plr.Object["status"] = utils.GeneratePlrStatus("managed1")
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
+		})
+		It("should propagate to cluster ns managed1 and managed2", func() {
+			By("Patching " + case10PolicySetName + "-plr with decision of cluster managed2")
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case10PolicySetName+"-plr", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plr.Object["status"] = utils.GeneratePlrStatus("managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed2", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
+		})
+		It("should clean up", func() {
+			By("Deleting " + case10PolicySetYaml)
+			_, err := utils.KubectlWithOutput("delete",
+				"-f", case10PolicySetPolicyYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, false, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		})
+	})
+
+	Describe("Test policy propagation through policyset placementbinding with placement", func() {
+		It("should be created in user ns", func() {
+			By("Creating " + case10PolicySetPlacementYaml)
+			_, err := utils.KubectlWithOutput("apply",
+				"-f", case10PolicySetPlacementYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).NotTo(BeNil())
+		})
+		It("should propagate to cluster ns managed1", func() {
+			By("Patching test-policy-plm with decision of cluster managed1")
+			plm := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementDecision, case10PolicySetName+"-plm-decision", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plm.Object["status"] = utils.GeneratePldStatus(plm.GetName(), plm.GetNamespace(), "managed1")
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plm, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
+		})
+		It("should propagate to cluster ns managed2", func() {
+			By("Patching test-policy-plm with decision of cluster managed2")
+			plm := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementDecision, case10PolicySetName+"-plm-decision", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plm.Object["status"] = utils.GeneratePldStatus(plm.GetName(), plm.GetNamespace(), "managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plm, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed2", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
+		})
+		It("should propagate to both cluster ns managed1 and managed2", func() {
+			By("Patching test-policy-plm with decision of cluster managed2")
+			plm := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementDecision, case10PolicySetName+"-plm-decision", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plm.Object["status"] = utils.GeneratePldStatus(plm.GetName(), plm.GetNamespace(), "managed1", "managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plm, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			plc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed2", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
+		})
+		It("should remove policy from ns managed1 and managed2", func() {
+			By("Deleting policyset")
+			_, err := utils.KubectlWithOutput("delete", "policyset", case10PolicySetName, "-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, false, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		})
+		It("should be created in user ns", func() {
+			By("Creating " + case10PolicySetPlacementYaml)
+			_, err := utils.KubectlWithOutput("apply",
+				"-f", case10PolicySetPlacementYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).NotTo(BeNil())
+		})
+		It("should propagate to both cluster ns managed1 and managed2", func() {
+			By("Patching test-policy-plm with decision of cluster managed2")
+			plm := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementDecision, case10PolicySetName+"-plm-decision", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plm.Object["status"] = utils.GeneratePldStatus(plm.GetName(), plm.GetNamespace(), "managed1", "managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plm, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			plc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed2", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
+		})
+		It("should remove policy from ns managed1 and managed2", func() {
+			By("Deleting placementbinding")
+			_, err := utils.KubectlWithOutput("delete", "PlacementBinding", case10PolicySetName+"-pb", "-n",
+				testNamespace)
+			Expect(err).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		})
+		It("should be created in user ns", func() {
+			By("Creating " + case10PolicySetPlacementYaml)
+			_, err := utils.KubectlWithOutput("apply",
+				"-f", case10PolicySetPlacementYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).NotTo(BeNil())
+		})
+		It("should propagate to both cluster ns managed1 and managed2", func() {
+			By("Patching test-policy-plm with decision of cluster managed2")
+			plm := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementDecision, case10PolicySetName+"-plm-decision", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plm.Object["status"] = utils.GeneratePldStatus(plm.GetName(), plm.GetNamespace(), "managed1", "managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plm, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			plc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed2", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
+		})
+		It("should remove policy from ns managed1 and managed2", func() {
+			By("Deleting placementDecision")
+			_, err := utils.KubectlWithOutput("delete", "PlacementDecision", case10PolicySetName+"-plm-decision", "-n",
+				testNamespace)
+			Expect(err).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		})
+		It("should be created in user ns", func() {
+			By("Creating " + case10PolicySetPlacementYaml)
+			_, err := utils.KubectlWithOutput("apply",
+				"-f", case10PolicySetPlacementYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).NotTo(BeNil())
+		})
+		It("should cleanup", func() {
+			By("Deleting " + case10PolicySetPlacementYaml)
+			_, err := utils.KubectlWithOutput("delete",
+				"-f", case10PolicySetPlacementYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, false, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		})
+	})
+
+	Describe("Test policy propagation through both policy and policyset placementbinding with placement", func() {
+		It("should be created in user ns", func() {
+			By("Creating " + case10PolicySetPolicyPlacementYaml)
+			_, err := utils.KubectlWithOutput("apply",
+				"-f", case10PolicySetPolicyPlacementYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).NotTo(BeNil())
+		})
+		It("should propagate to cluster ns managed1", func() {
+			By("Patching test-policy-plm with decision of cluster managed1")
+			plm := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementDecision, case10PolicyName+"-plm-decision", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plm.Object["status"] = utils.GeneratePldStatus(plm.GetName(), plm.GetNamespace(), "managed1")
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plm, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
+		})
+		It("should propagate to both cluster ns managed1 and managed2", func() {
+			By("Patching test-policyset-plm with decision of cluster managed2")
+			plm := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementDecision, case10PolicySetName+"-plm-decision", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plm.Object["status"] = utils.GeneratePldStatus(plm.GetName(), plm.GetNamespace(), "managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plm, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			plc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName, "managed2", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 2, true, defaultTimeoutSeconds)
+		})
+		It("should cleanup", func() {
+			By("Deleting " + case10PolicySetPolicyPlacementYaml)
+			_, err := utils.KubectlWithOutput("delete",
+				"-f", case10PolicySetPolicyPlacementYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, false, defaultTimeoutSeconds,
+			)
+			Expect(plcSet).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		})
+	})
+})

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -30,6 +30,7 @@ var (
 	clientHubDynamic      dynamic.Interface
 	gvrPolicy             schema.GroupVersionResource
 	gvrPolicyAutomation   schema.GroupVersionResource
+	gvrPolicySet          schema.GroupVersionResource
 	gvrPlacementBinding   schema.GroupVersionResource
 	gvrPlacementRule      schema.GroupVersionResource
 	gvrPlacement          schema.GroupVersionResource
@@ -53,6 +54,9 @@ var _ = BeforeSuite(func() {
 	By("Setup Hub client")
 	gvrPolicy = schema.GroupVersionResource{
 		Group: "policy.open-cluster-management.io", Version: "v1", Resource: "policies",
+	}
+	gvrPolicySet = schema.GroupVersionResource{
+		Group: "policy.open-cluster-management.io", Version: "v1", Resource: "policysets",
 	}
 	gvrPlacementBinding = schema.GroupVersionResource{
 		Group: "policy.open-cluster-management.io", Version: "v1", Resource: "placementbindings",

--- a/test/resources/case10_policyset_propagation/case10-test-policyset-placement.yaml
+++ b/test/resources/case10_policyset_propagation/case10-test-policyset-placement.yaml
@@ -1,0 +1,62 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case10-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case1-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicySet
+metadata:
+  name: case10-test-policyset
+spec:
+  policies:
+  - case10-test-policy
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case10-test-policyset-pb
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+  name: case10-test-policyset-plm
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: PolicySet
+  name: case10-test-policyset
+---
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: Placement
+metadata:
+  name: case10-test-policyset-plm
+spec:
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions: []
+---
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: PlacementDecision
+metadata:
+  name: case10-test-policyset-plm-decision
+  labels:
+    cluster.open-cluster-management.io/placement: case10-test-policyset-plm
+status:
+  decisions:
+  - clusterName: local-cluster
+    reason: ""

--- a/test/resources/case10_policyset_propagation/case10-test-policyset-policy-placement.yaml
+++ b/test/resources/case10_policyset_propagation/case10-test-policyset-policy-placement.yaml
@@ -1,0 +1,96 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case10-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case1-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case10-test-policy-pb
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+  name: case10-test-policy-plm
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: case10-test-policy
+---
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: Placement
+metadata:
+  name: case10-test-policy-plm
+spec:
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions: []
+---
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: PlacementDecision
+metadata:
+  name: case10-test-policy-plm-decision
+  labels:
+    cluster.open-cluster-management.io/placement: case10-test-policy-plm
+status:
+  decisions:
+  - clusterName: managed1
+    reason: ""
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicySet
+metadata:
+  name: case10-test-policyset
+spec:
+  policies:
+  - case10-test-policy
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case10-test-policyset-pb
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+  name: case10-test-policyset-plm
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: PolicySet
+  name: case10-test-policyset
+---
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: Placement
+metadata:
+  name: case10-test-policyset-plm
+spec:
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions: []
+---
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: PlacementDecision
+metadata:
+  name: case10-test-policyset-plm-decision
+  labels:
+    cluster.open-cluster-management.io/placement: case10-test-policyset-plm
+status:
+  decisions:
+  - clusterName: managed1
+    reason: ""

--- a/test/resources/case10_policyset_propagation/case10-test-policyset-policy.yaml
+++ b/test/resources/case10_policyset_propagation/case10-test-policyset-policy.yaml
@@ -1,0 +1,78 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case10-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case1-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case10-test-policy-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: case10-test-policy-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: case10-test-policy
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: case10-test-policy-plr
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      []
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicySet
+metadata:
+  name: case10-test-policyset
+spec:
+  policies:
+  - case10-test-policy
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case10-test-policyset-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: case10-test-policyset-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: PolicySet
+  name: case10-test-policyset
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: case10-test-policyset-plr
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      []

--- a/test/resources/case10_policyset_propagation/case10-test-policyset.yaml
+++ b/test/resources/case10_policyset_propagation/case10-test-policyset.yaml
@@ -1,0 +1,53 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case10-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case1-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicySet
+metadata:
+  name: case10-test-policyset
+spec:
+  policies:
+  - case10-test-policy
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case10-test-policyset-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: case10-test-policyset-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: PolicySet
+  name: case10-test-policyset
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: case10-test-policyset-plr
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      []


### PR DESCRIPTION
stolostron/backlog#18401
- Added watch on `PolicySet` resources
- Implemented a mapper and predicate for `PolicySet` watch
- Added `PolicySet` to pb.subject.kind enum list
- Added `PolicySet` support to existing mapper and predicate
- Added `PolicySet` field to status.placement

Signed-off-by: Yu Cao <ycao@redhat.com>