### PR TITLE
Ensure reconcile requests are generated correctly

### DIFF
--- a/controllers/propagator/placementBindingMapper.go
+++ b/controllers/propagator/placementBindingMapper.go
@@ -44,7 +44,10 @@ func placementBindingMapper(c client.Client) handler.MapFunc {
 					policySet := &policiesv1.PolicySet{}
 					err := c.Get(context.TODO(), policySetNamespacedName, policySet)
 					if err != nil {
-						return nil
+						log.V(2).Info("Failed to retrieve policyset referenced in placementbinding",
+							"policySetName", subject.Name, "error", err)
+
+						continue
 					}
 					policies := policySet.Spec.Policies
 					for _, plc := range policies {

--- a/controllers/propagator/placementDecisionMapper.go
+++ b/controllers/propagator/placementDecisionMapper.go
@@ -67,7 +67,10 @@ func placementDecisionMapper(c client.Client) handler.MapFunc {
 						policySet := &policiesv1.PolicySet{}
 						err := c.Get(context.TODO(), policySetNamespacedName, policySet)
 						if err != nil {
-							return nil
+							log.V(2).Info("Failed to retrieve policyset referenced in placementbinding",
+								"policySetName", subject.Name, "placementBindingName", pb.GetName(), "error", err)
+
+							continue
 						}
 						policies := policySet.Spec.Policies
 						for _, plc := range policies {

--- a/controllers/propagator/placementRuleMapper.go
+++ b/controllers/propagator/placementRuleMapper.go
@@ -57,7 +57,10 @@ func placementRuleMapper(c client.Client) handler.MapFunc {
 							policySet := &policiesv1.PolicySet{}
 							err := c.Get(context.TODO(), policySetNamespacedName, policySet)
 							if err != nil {
-								return nil
+								log.V(2).Info("Failed to retrieve policyset referenced in placementbinding",
+									"policySetName", subject.Name, "placementBindingName", pb.GetName(), "error", err)
+
+								continue
 							}
 							policies := policySet.Spec.Policies
 							for _, plc := range policies {

--- a/test/e2e/case10_policyset_propagation_test.go
+++ b/test/e2e/case10_policyset_propagation_test.go
@@ -9,7 +9,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
+	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
 	"github.com/stolostron/governance-policy-propagator/controllers/common"
 	"github.com/stolostron/governance-policy-propagator/test/utils"
 )
@@ -883,6 +885,159 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Deleting " + case10PolicySetMultipleYaml)
 			_, err := utils.KubectlWithOutput("delete",
 				"-f", case10PolicySetMultipleYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet1 := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName+"1", testNamespace, false, defaultTimeoutSeconds,
+			)
+			Expect(plcSet1).To(BeNil())
+			plcSet2 := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName+"2", testNamespace, false, defaultTimeoutSeconds,
+			)
+			Expect(plcSet2).To(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		})
+	})
+
+	Describe("Test policy propagation with multiple policysets with single placementbinding", func() {
+		const case10PolicySetMultipleSinglePBYaml string = path + "case10-test-multiple-policysets-single-pb.yaml"
+		It("should be created in user ns", func() {
+			By("Creating " + case10PolicySetMultipleSinglePBYaml)
+			_, err := utils.KubectlWithOutput("apply",
+				"-f", case10PolicySetMultipleSinglePBYaml,
+				"-n", testNamespace)
+			Expect(err).To(BeNil())
+			plcSet1 := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName+"1", testNamespace, true, defaultTimeoutSeconds,
+			)
+			Expect(plcSet1).NotTo(BeNil())
+			plcSet2 := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicySet, case10PolicySetName+"2", testNamespace, true, defaultTimeoutSeconds,
+			)
+			Expect(plcSet2).NotTo(BeNil())
+		})
+		It("should propagate to cluster ns managed1", func() {
+			By("Patching " + case10PolicySetName + "-plm with decision of cluster managed1")
+			plm := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementDecision, case10PolicySetName+"-plm-decision", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plm.Object["status"] = utils.GeneratePldStatus(plm.GetName(), plm.GetNamespace(), "managed1")
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plm, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName+"1", "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName + "1",
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
+			plc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName+"2", "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt = metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName + "2",
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
+		})
+		It("should propagate to cluster ns managed2", func() {
+			By("Patching " + case10PolicySetName + "-plm with decision of cluster managed2")
+			plm := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementDecision, case10PolicySetName+"-plm-decision", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plm.Object["status"] = utils.GeneratePldStatus(plm.GetName(), plm.GetNamespace(), "managed2")
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plm, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName+"1", "managed1", false,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).To(BeNil())
+			plc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName+"1", "managed2", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).NotTo(BeNil())
+			plc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName+"2", "managed1", false,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).To(BeNil())
+			plc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName+"2", "managed2", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).NotTo(BeNil())
+		})
+		It("should still work when pb contains non-existing policyset", func() {
+			By("Patching " + case10PolicySetName + "-pb with non-existing policyset")
+			unstructuredPb := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementBinding, case10PolicySetName+"-pb", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			var pb policiesv1.PlacementBinding
+			err := runtime.DefaultUnstructuredConverter.
+				FromUnstructured(unstructuredPb.UnstructuredContent(), &pb)
+			Expect(err).To(BeNil())
+			nonExistingSubject := []policiesv1.Subject{
+				{
+					APIGroup: "policy.open-cluster-management.io",
+					Kind:     "PolicySet",
+					Name:     case10PolicySetName,
+				},
+			}
+			unstructuredPb.Object["subjects"] = append(nonExistingSubject, pb.Subjects[0], pb.Subjects[1])
+			_, err = clientHubDynamic.Resource(gvrPlacementBinding).Namespace(testNamespace).Update(
+				context.TODO(), unstructuredPb, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+		})
+		It("should still propagate to cluster ns managed1", func() {
+			By("Patching " + case10PolicySetName + "-plm with decision of cluster managed1")
+			plm := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementDecision, case10PolicySetName+"-plm-decision", testNamespace, true,
+				defaultTimeoutSeconds,
+			)
+			plm.Object["status"] = utils.GeneratePldStatus(plm.GetName(), plm.GetNamespace(), "managed1")
+			_, err := clientHubDynamic.Resource(gvrPlacementDecision).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plm, metav1.UpdateOptions{},
+			)
+			Expect(err).To(BeNil())
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName+"1", "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt := metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName + "1",
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
+			plc = utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case10PolicyName+"2", "managed1", true,
+				defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+			opt = metav1.ListOptions{
+				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName + "2",
+			}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
+		})
+		It("should cleanup", func() {
+			By("Deleting " + case10PolicySetMultipleSinglePBYaml)
+			_, err := utils.KubectlWithOutput("delete",
+				"-f", case10PolicySetMultipleSinglePBYaml,
 				"-n", testNamespace)
 			Expect(err).To(BeNil())
 			plcSet1 := utils.GetWithTimeout(

--- a/test/resources/case10_policyset_propagation/case10-test-multiple-policysets-single-pb.yaml
+++ b/test/resources/case10_policyset_propagation/case10-test-multiple-policysets-single-pb.yaml
@@ -1,0 +1,94 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case10-test-policy1
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case10-test-policy1-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case10-test-policy2
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case10-test-policy2-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicySet
+metadata:
+  name: case10-test-policyset1
+spec:
+  policies:
+  - case10-test-policy1
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicySet
+metadata:
+  name: case10-test-policyset2
+spec:
+  policies:
+  - case10-test-policy2
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case10-test-policyset-pb
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+  name: case10-test-policyset-plm
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: PolicySet
+  name: case10-test-policyset1
+- apiGroup: policy.open-cluster-management.io
+  kind: PolicySet
+  name: case10-test-policyset2
+---
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: Placement
+metadata:
+  name: case10-test-policyset-plm
+spec:
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions: []
+---
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: PlacementDecision
+metadata:
+  name: case10-test-policyset-plm-decision
+  labels:
+    cluster.open-cluster-management.io/placement: case10-test-policyset-plm
+status:
+  decisions:
+  - clusterName: managed2
+    reason: ""


### PR DESCRIPTION
When a placementbinding references multiple subjects, the mapper should 
always loop through entire subjects to generate reconcile request even when a 
policyset couldn't be retrieved.

Signed-off-by: Yu Cao <ycao@redhat.com>