### PR TITLE
Add the policy-encryption-keys controller

### DIFF
--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -4,6 +4,10 @@
 package common
 
 import (
+	"time"
+
+	"github.com/avast/retry-go/v3"
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/equality"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
@@ -91,4 +95,15 @@ func FindNonCompliantClustersForPolicy(plc *policiesv1.Policy) []string {
 	}
 
 	return clusterList
+}
+
+// GetRetryOptions returns reasonable options to call retry.Do with.
+func GetRetryOptions(logger logr.Logger, retryMsg string, attempts uint) []retry.Option {
+	return []retry.Option{
+		retry.Attempts(attempts),
+		retry.Delay(2 * time.Second),
+		retry.MaxDelay(10 * time.Second),
+		retry.OnRetry(func(n uint, err error) { logger.Info(retryMsg) }),
+		retry.LastErrorOnly(true),
+	}
 }

--- a/controllers/encryptionkeys/encryptionkeys_controller.go
+++ b/controllers/encryptionkeys/encryptionkeys_controller.go
@@ -1,0 +1,300 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package encryptionkeys
+
+import (
+	"context"
+	"crypto/aes"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/avast/retry-go/v3"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	policyv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	"github.com/stolostron/governance-policy-propagator/controllers/common"
+	"github.com/stolostron/governance-policy-propagator/controllers/propagator"
+)
+
+const (
+	ControllerName = "policy-encryption-keys"
+	// This is used for when an administrator prefers to manually generate the encryption keys
+	// instead of letting the Policy Propagator handle it.
+	DisableRotationAnnotation = "policy.open-cluster-management.io/disable-rotation"
+)
+
+var (
+	log                       = ctrl.Log.WithName(ControllerName)
+	errLastRotationParseError = fmt.Errorf(`failed to parse the "%s" annotation`, propagator.LastRotatedAnnotation)
+	// The number of retries when performing an operation that can fail temporarily and can't be
+	// requeued for a retry later. This is not a const so it can be overwritten during the tests.
+	retries uint = 4
+)
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *EncryptionKeysReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		// The work queue prevents the same item being reconciled concurrently:
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/1416#issuecomment-899833144
+		WithOptions(controller.Options{MaxConcurrentReconciles: int(r.MaxConcurrentReconciles)}).
+		Named(ControllerName).
+		For(&corev1.Secret{}).
+		Complete(r)
+}
+
+// blank assignment to verify that EncryptionKeysReconciler implements reconcile.Reconciler
+var _ reconcile.Reconciler = &EncryptionKeysReconciler{}
+
+// EncryptionKeysReconciler is responsible for rotating the AES encryption key in the "policy-encryption-key" Secrets
+// for all managed clusters.
+type EncryptionKeysReconciler struct { // nolint:golint,revive
+	client.Client
+	KeyRotationDays         uint
+	MaxConcurrentReconciles uint
+	Scheme                  *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=get;list;patch
+//+kubebuilder:rbac:groups=core,resources=secrets,resourceNames=policy-encryption-key,verbs=get;update;watch
+
+// Reconcile watches all "policy-encryption-key" Secrets on the Hub cluster. This periodically rotates the keys
+// and resolves invalid modifications made to the Secret.
+func (r *EncryptionKeysReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	log := log.WithValues("secretNamespace", request.Namespace, "secret", request.Name)
+	log.Info("Reconciling a Secret")
+
+	clusterName := request.Namespace
+
+	// The cache configuration of SelectorsByObject should prevent this from happening, but add this as a precaution.
+	if request.Name != propagator.EncryptionKeySecret {
+		log.Info("Got a reconciliation request for an unexpected Secret. This should have been filtered out.")
+
+		return reconcile.Result{}, nil
+	}
+
+	secret := &corev1.Secret{}
+
+	err := r.Get(ctx, request.NamespacedName, secret)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.V(2).Info("The Secret was not found on the server. Doing nothing.")
+
+			return ctrl.Result{}, nil
+		}
+
+		log.Error(err, "Failed to get the Secret from the server. Will retry the reconcile request.")
+
+		return ctrl.Result{}, err
+	}
+
+	annotations := secret.GetAnnotations()
+	if strings.EqualFold(annotations[DisableRotationAnnotation], "true") {
+		log.Info(
+			"Encountered an encryption key Secret with key rotation disabled. Will trigger a policy template update.",
+			"annotation", DisableRotationAnnotation,
+			"value", annotations[DisableRotationAnnotation],
+		)
+
+		// In case the key was manually rotated, trigger a template update
+		r.triggerTemplateUpdate(ctx, clusterName, secret)
+
+		return reconcile.Result{}, nil
+	}
+
+	lastRotatedTS := annotations[propagator.LastRotatedAnnotation]
+	log = log.WithValues("annotation", propagator.LastRotatedAnnotation, "value", lastRotatedTS)
+
+	var nextRotation time.Duration
+
+	if lastRotatedTS == "" {
+		log.Info("The annotation is not set. Will rotate the key now.")
+
+		nextRotation = 0
+	} else {
+		nextRotation, err = r.getNextRotationFromNow(secret)
+		if err != nil {
+			log.Error(err, "The annotation cannot be parsed. Will rotate the key now.")
+			nextRotation = 0
+		}
+	}
+
+	_, err = aes.NewCipher(secret.Data["key"])
+	if err != nil {
+		log.Error(err, "The encryption key in the Secret is invalid. Will rotate the key now.")
+
+		nextRotation = 0
+		// Set this to a null value so the bad key doesn't get stored as the previous key
+		secret.Data["key"] = []byte{}
+	}
+
+	if nextRotation > 0 {
+		// previousKey only needs to be checked if there won't be a rotation since it would get overwritten anyways
+		if len(secret.Data["previousKey"]) > 0 {
+			// If previousKey is invalid, it'll cause go-template-utils to fail on the managed cluster, so remove it if
+			// a user changed this accidentally
+			_, err = aes.NewCipher(secret.Data["previousKey"])
+			if err != nil {
+				log.Info("The previous encryption key in the Secret is invalid. Will remove it.")
+
+				secret.Data["previousKey"] = []byte{}
+
+				err := r.Update(ctx, secret)
+				if err != nil {
+					log.Error(err, "Failed to update the Secret. Will retry the request.")
+
+					return reconcile.Result{}, err
+				}
+			}
+		}
+
+		log.V(2).Info("The key is not yet ready to be rotated")
+
+		// Requeueing the same object multiple times is safe as the queue will drop any scheduled
+		// requeues in favor of this one
+		// https://github.com/kubernetes-sigs/controller-runtime/blob/7ba3e559790c5e3543002a0d9670b4cef3ccf743/pkg/internal/controller/controller.go#L323-L324
+		return reconcile.Result{RequeueAfter: nextRotation}, nil
+	}
+
+	log.V(1).Info("Rotating the encryption key")
+
+	err = r.rotateKey(ctx, secret)
+	if err != nil {
+		log.Error(err, "Failed to rotate the encryption key. Will retry the request.")
+
+		return reconcile.Result{}, err
+	}
+
+	r.triggerTemplateUpdate(ctx, clusterName, secret)
+
+	// The error is ignored since this can't fail since the annotation value was just set to a valid value
+	nextRotation, _ = r.getNextRotationFromNow(secret)
+
+	log.Info("Rotated the encryption key successfully", "nextRotation", nextRotation)
+
+	return reconcile.Result{RequeueAfter: nextRotation}, nil
+}
+
+// getNextRotationFromNow will return the duration from now until the next key rotation. An error is
+// returned if the last rotated annotation cannot be parsed.
+func (r *EncryptionKeysReconciler) getNextRotationFromNow(secret *corev1.Secret) (time.Duration, error) {
+	annotations := secret.GetAnnotations()
+	lastRotatedTS := annotations[propagator.LastRotatedAnnotation]
+
+	lastRotated, err := time.Parse(time.RFC3339, lastRotatedTS)
+	if err != nil {
+		return 0, fmt.Errorf(`%w with value "%s": %v`, errLastRotationParseError, lastRotatedTS, err)
+	}
+
+	nextRotation := lastRotated.Add(time.Hour * 24 * time.Duration(r.KeyRotationDays))
+
+	return time.Until(nextRotation), nil
+}
+
+// rotateKey will generate a new encryption key to replace the "key" field/key on the Secret. The
+// old key is stored as the "previousKey" field/key on the Secret. The Secret is then updated
+// with the Kubernetes API server. An error is returned if the key can't be generated or the
+// update on the API servier fails.
+func (r *EncryptionKeysReconciler) rotateKey(ctx context.Context, secret *corev1.Secret) error {
+	newKey, err := propagator.GenerateEncryptionKey()
+	if err != nil {
+		return err
+	}
+
+	secret.Data["previousKey"] = secret.Data["key"]
+	secret.Data["key"] = newKey
+
+	annotations := secret.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	lastRotatedTS := time.Now().UTC().Format(time.RFC3339)
+	annotations[propagator.LastRotatedAnnotation] = lastRotatedTS
+	secret.SetAnnotations(annotations)
+
+	return r.Update(ctx, secret)
+}
+
+// triggerTemplateUpdate finds all the policies that this managed cluster uses that use encryption.
+// It then updates those root policies with the trigger-update annotation to cause the policies to
+// be reprocessed with the new key.
+func (r *EncryptionKeysReconciler) triggerTemplateUpdate(
+	ctx context.Context, clusterName string, secret *corev1.Secret,
+) {
+	log.Info(
+		"Triggering template updates on all the managed cluster policies that use encryption", "cluster", clusterName,
+	)
+
+	policies := policyv1.PolicyList{}
+	// Get all the policies in the cluster namespace
+	err := retry.Do(
+		func() error {
+			return r.List(ctx, &policies, client.InNamespace(clusterName))
+		},
+		common.GetRetryOptions(log.V(1), "Retrying to list the managed cluster policy templates", retries+1)...,
+	)
+	if err != nil {
+		log.Error(err, "Failed to trigger all the policies to be reprocessed after the key rotation")
+
+		return
+	}
+
+	// Setting this value to something unique for this key rotation ensures the annotation will be updated to
+	// a new value and thus trigger an update
+	value := fmt.Sprintf("rotate-key-%s-%s", clusterName, secret.Annotations[propagator.LastRotatedAnnotation])
+	patch := []byte(`{"metadata":{"annotations":{"` + propagator.TriggerUpdateAnnotation + `":"` + value + `"}}}`)
+
+	for _, policy := range policies.Items {
+		// If the policy does not have the initialization vector annotation, then encryption is not
+		// used and thus doesn't need to be reprocessed
+		if _, ok := policy.Annotations[propagator.IVAnnotation]; !ok {
+			continue
+		}
+
+		// Find the root policy to patch with the annotation
+		rootPlcName := policy.GetLabels()[common.RootPolicyLabel]
+		if rootPlcName == "" {
+			log.Info(
+				"The replicated policy does not have the root policy label set",
+				"policy", policy.ObjectMeta.Name,
+				"label", common.RootPolicyLabel,
+			)
+
+			continue
+		}
+
+		rootPolicy := &policyv1.Policy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: strings.Split(rootPlcName, ".")[0],
+				Name:      strings.Split(rootPlcName, ".")[1],
+			},
+		}
+
+		err := retry.Do(
+			func() error {
+				return r.Patch(ctx, rootPolicy, client.RawPatch(types.MergePatchType, patch))
+			},
+			common.GetRetryOptions(
+				log.V(1), "Retrying to trigger the policy templates to be reprocessed", retries+1,
+			)...,
+		)
+		if err != nil {
+			log.Error(
+				err,
+				"Failed to trigger the policy to be reprocessed after the key rotation",
+				"policyName",
+				rootPlcName,
+			)
+		}
+	}
+}

--- a/controllers/encryptionkeys/encryptionkeys_controller_test.go
+++ b/controllers/encryptionkeys/encryptionkeys_controller_test.go
@@ -1,0 +1,534 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package encryptionkeys
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	"github.com/stolostron/governance-policy-propagator/controllers/common"
+	"github.com/stolostron/governance-policy-propagator/controllers/propagator"
+)
+
+const (
+	keySize     = 256
+	clusterName = "local-cluster"
+	day         = time.Hour * 24
+)
+
+type erroringFakeClient struct {
+	client.Client
+	GetError    bool
+	ListError   bool
+	PatchError  bool
+	UpdateError bool
+}
+
+func (c *erroringFakeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	if c.GetError {
+		return errors.New("some get error")
+	}
+
+	return c.Client.Get(ctx, key, obj)
+}
+
+func (c *erroringFakeClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if c.ListError {
+		return errors.New("some list error")
+	}
+
+	return c.Client.List(ctx, list, opts...)
+}
+
+func (c *erroringFakeClient) Patch(
+	ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption,
+) error {
+	if c.PatchError {
+		return errors.New("some patch error")
+	}
+
+	return c.Client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *erroringFakeClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if c.UpdateError {
+		return errors.New("some update error")
+	}
+
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func generateSecret() *corev1.Secret {
+	key := make([]byte, keySize/8)
+	_, err := rand.Read(key)
+	Expect(err).To(BeNil())
+
+	encryptionSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      propagator.EncryptionKeySecret,
+			Namespace: clusterName,
+		},
+		Data: map[string][]byte{"key": key},
+	}
+
+	prevKey := make([]byte, keySize/8)
+	_, err = rand.Read(prevKey)
+	Expect(err).To(BeNil())
+
+	encryptionSecret.Data["previousKey"] = prevKey
+
+	return encryptionSecret
+}
+
+func generatePolicies() []client.Object {
+	return []client.Object{
+		client.Object(
+			&v1.Policy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "default.policy-one",
+					Namespace:   clusterName,
+					Annotations: map[string]string{propagator.IVAnnotation: "7cznVUq5SXEE4RMZNkGOrQ=="},
+					Labels:      map[string]string{common.RootPolicyLabel: "default.policy-one"},
+				},
+			},
+		),
+		client.Object(
+			&v1.Policy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "policy-one",
+					Namespace:   "default",
+					Annotations: map[string]string{},
+				},
+			},
+		),
+		client.Object(
+			&v1.Policy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "default.policy-two",
+					Namespace:   clusterName,
+					Annotations: map[string]string{},
+					Labels:      map[string]string{common.RootPolicyLabel: "default.policy-two"},
+				},
+			},
+		),
+		client.Object(
+			&v1.Policy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "policy-two",
+					Namespace:   "default",
+					Annotations: map[string]string{},
+				},
+			},
+		),
+		client.Object(
+			&v1.Policy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "default.policy-three",
+					Namespace:   "some-other-cluster",
+					Annotations: map[string]string{propagator.IVAnnotation: "7cznVUq5SXEE4RMZNkGOrQ=="},
+					Labels:      map[string]string{common.RootPolicyLabel: "default.policy-three"},
+				},
+			},
+		),
+		client.Object(
+			&v1.Policy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "policy-three",
+					Namespace:   "default",
+					Annotations: map[string]string{},
+				},
+			},
+		),
+		client.Object(
+			&v1.Policy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "default.policy-four",
+					Namespace:   clusterName,
+					Annotations: map[string]string{propagator.IVAnnotation: "7cznVUq5SXEE4RMZNkGOrQ=="},
+					Labels:      map[string]string{common.RootPolicyLabel: "default.policy-four"},
+				},
+			},
+		),
+		client.Object(
+			&v1.Policy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "policy-four",
+					Namespace:   "default",
+					Annotations: map[string]string{},
+				},
+			},
+		),
+	}
+}
+
+func getRequeueAfterDays(result reconcile.Result) int {
+	return int(result.RequeueAfter.Round(day) / (day))
+}
+
+func getReconciler(encryptionSecret *corev1.Secret) *EncryptionKeysReconciler {
+	policies := generatePolicies()
+
+	scheme := k8sruntime.NewScheme()
+	err := clientgoscheme.AddToScheme(scheme)
+	Expect(err).To(BeNil())
+	err = v1.AddToScheme(scheme)
+	Expect(err).To(BeNil())
+
+	builder := fake.NewClientBuilder().WithObjects(policies...).WithScheme(scheme)
+
+	if encryptionSecret != nil {
+		builder = builder.WithObjects(encryptionSecret)
+	}
+
+	client := builder.Build()
+
+	return &EncryptionKeysReconciler{
+		Client:                  client,
+		KeyRotationDays:         30,
+		MaxConcurrentReconciles: 1,
+		Scheme:                  scheme,
+	}
+}
+
+func assertTriggerUpdate(r *EncryptionKeysReconciler) {
+	policyList := v1.PolicyList{}
+	err := r.List(context.TODO(), &policyList)
+	Expect(err).To(BeNil())
+
+	for _, policy := range policyList.Items {
+		annotation := policy.Annotations[propagator.TriggerUpdateAnnotation]
+
+		if policy.ObjectMeta.Name == "policy-one" || policy.ObjectMeta.Name == "policy-four" {
+			expectedPrefix := fmt.Sprintf("rotate-key-%s-", clusterName)
+			Expect(strings.HasPrefix(annotation, expectedPrefix)).To(BeTrue())
+		} else {
+			Expect(annotation).To(Equal(""))
+		}
+	}
+}
+
+func assertNoTriggerUpdate(r *EncryptionKeysReconciler) {
+	policyList := v1.PolicyList{}
+	err := r.List(context.TODO(), &policyList)
+	Expect(err).To(BeNil())
+
+	for _, policy := range policyList.Items {
+		annotation := policy.Annotations[propagator.TriggerUpdateAnnotation]
+		Expect(annotation).To(Equal(""))
+	}
+}
+
+func TestReconcileRotateKey(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+
+	tests := []struct{ Annotation string }{{""}, {"2020-04-15T01:02:03Z"}, {"not-a-timestamp"}}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(
+			fmt.Sprintf(`annotation="%s"`, test.Annotation),
+			func(t *testing.T) {
+				t.Parallel()
+
+				encryptionSecret := generateSecret()
+				if test.Annotation != "" {
+					annotations := map[string]string{propagator.LastRotatedAnnotation: test.Annotation}
+					encryptionSecret.SetAnnotations(annotations)
+				}
+				originalKey := encryptionSecret.Data["key"]
+
+				r := getReconciler(encryptionSecret)
+
+				secretID := types.NamespacedName{
+					Namespace: clusterName, Name: propagator.EncryptionKeySecret,
+				}
+				request := ctrl.Request{NamespacedName: secretID}
+				result, err := r.Reconcile(context.TODO(), request)
+
+				Expect(err).To(BeNil())
+				Expect(result.Requeue).To(BeFalse())
+				Expect(getRequeueAfterDays(result)).To(Equal(30))
+
+				err = r.Get(context.TODO(), secretID, encryptionSecret)
+				Expect(err).To(BeNil())
+				Expect(bytes.Equal(encryptionSecret.Data["key"], originalKey)).To(BeFalse())
+				Expect(bytes.Equal(encryptionSecret.Data["previousKey"], originalKey)).To(BeTrue())
+
+				assertTriggerUpdate(r)
+			},
+		)
+	}
+}
+
+func TestReconcileNoRotation(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+
+	encryptionSecret := generateSecret()
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	encryptionSecret.SetAnnotations(map[string]string{propagator.LastRotatedAnnotation: now})
+
+	originalKey := encryptionSecret.Data["key"]
+
+	r := getReconciler(encryptionSecret)
+
+	secretID := types.NamespacedName{
+		Namespace: clusterName, Name: propagator.EncryptionKeySecret,
+	}
+	request := ctrl.Request{NamespacedName: secretID}
+	result, err := r.Reconcile(context.TODO(), request)
+
+	Expect(err).To(BeNil())
+	Expect(getRequeueAfterDays(result)).To(Equal(30))
+
+	err = r.Get(context.TODO(), secretID, encryptionSecret)
+	Expect(err).To(BeNil())
+	Expect(bytes.Equal(encryptionSecret.Data["key"], originalKey)).To(BeTrue())
+	Expect(bytes.Equal(encryptionSecret.Data["previousKey"], originalKey)).To(BeFalse())
+
+	assertNoTriggerUpdate(r)
+}
+
+func TestReconcileNotFound(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+
+	r := getReconciler(nil)
+
+	secretID := types.NamespacedName{
+		Namespace: clusterName, Name: propagator.EncryptionKeySecret,
+	}
+	request := ctrl.Request{NamespacedName: secretID}
+	result, err := r.Reconcile(context.TODO(), request)
+
+	Expect(err).To(BeNil())
+	Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+	policyList := v1.PolicyList{}
+	err = r.List(context.TODO(), &policyList)
+	Expect(err).To(BeNil())
+
+	for _, policy := range policyList.Items {
+		annotation := policy.Annotations[propagator.TriggerUpdateAnnotation]
+		Expect(annotation).To(Equal(""))
+	}
+}
+
+func TestReconcileManualRotation(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+
+	encryptionSecret := generateSecret()
+	annotations := map[string]string{
+		"policy.open-cluster-management.io/disable-rotation": "true",
+		propagator.LastRotatedAnnotation:                     "2020-04-15T01:02:03Z",
+	}
+	encryptionSecret.SetAnnotations(annotations)
+	originalKey := encryptionSecret.Data["key"]
+	originalPrevKey := encryptionSecret.Data["previousKey"]
+
+	r := getReconciler(encryptionSecret)
+
+	secretID := types.NamespacedName{
+		Namespace: clusterName, Name: propagator.EncryptionKeySecret,
+	}
+	request := ctrl.Request{NamespacedName: secretID}
+	result, err := r.Reconcile(context.TODO(), request)
+
+	Expect(err).To(BeNil())
+	Expect(result.Requeue).To(BeFalse())
+	Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+	err = r.Get(context.TODO(), secretID, encryptionSecret)
+	Expect(err).To(BeNil())
+	Expect(bytes.Equal(encryptionSecret.Data["key"], originalKey)).To(BeTrue())
+	Expect(bytes.Equal(encryptionSecret.Data["previousKey"], originalPrevKey)).To(BeTrue())
+
+	assertTriggerUpdate(r)
+}
+
+func TestReconcileInvalidKey(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+
+	encryptionSecret := generateSecret()
+	encryptionSecret.Data["key"] = []byte("not-a-key")
+	originalKey := encryptionSecret.Data["key"]
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	encryptionSecret.SetAnnotations(map[string]string{propagator.LastRotatedAnnotation: now})
+
+	r := getReconciler(encryptionSecret)
+
+	secretID := types.NamespacedName{
+		Namespace: clusterName, Name: propagator.EncryptionKeySecret,
+	}
+	request := ctrl.Request{NamespacedName: secretID}
+	result, err := r.Reconcile(context.TODO(), request)
+
+	Expect(err).To(BeNil())
+	Expect(result.Requeue).To(BeFalse())
+	Expect(getRequeueAfterDays(result)).To(Equal(30))
+
+	err = r.Get(context.TODO(), secretID, encryptionSecret)
+	Expect(err).To(BeNil())
+	Expect(bytes.Equal(encryptionSecret.Data["key"], originalKey)).To(BeFalse())
+	Expect(len(encryptionSecret.Data["previousKey"])).To(Equal(0))
+
+	assertTriggerUpdate(r)
+}
+
+func TestReconcileInvalidPreviousKey(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+
+	encryptionSecret := generateSecret()
+	encryptionSecret.Data["previousKey"] = []byte("not-a-key")
+	originalKey := encryptionSecret.Data["key"]
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	encryptionSecret.SetAnnotations(map[string]string{propagator.LastRotatedAnnotation: now})
+
+	r := getReconciler(encryptionSecret)
+
+	secretID := types.NamespacedName{
+		Namespace: clusterName, Name: propagator.EncryptionKeySecret,
+	}
+	request := ctrl.Request{NamespacedName: secretID}
+	result, err := r.Reconcile(context.TODO(), request)
+
+	Expect(err).To(BeNil())
+	Expect(result.Requeue).To(BeFalse())
+	Expect(getRequeueAfterDays(result)).To(Equal(30))
+
+	err = r.Get(context.TODO(), secretID, encryptionSecret)
+	Expect(err).To(BeNil())
+	Expect(bytes.Equal(encryptionSecret.Data["key"], originalKey)).To(BeTrue())
+	Expect(len(encryptionSecret.Data["previousKey"])).To(Equal(0))
+
+	assertNoTriggerUpdate(r)
+}
+
+func TestReconcileSecretNotFiltered(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+
+	randomSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "random-secret",
+			Namespace: clusterName,
+		},
+	}
+
+	r := getReconciler(randomSecret)
+
+	secretID := types.NamespacedName{Namespace: clusterName, Name: "random-secret"}
+	request := ctrl.Request{NamespacedName: secretID}
+	result, err := r.Reconcile(context.TODO(), request)
+
+	Expect(err).To(BeNil())
+	Expect(result.Requeue).To(BeFalse())
+	Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+	assertNoTriggerUpdate(r)
+}
+
+func TestReconcileAPIFails(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+
+	originalRetries := retries
+	retries = 0
+
+	t.Cleanup(func() { retries = originalRetries })
+
+	tests := []struct {
+		ExpectedRotation bool
+		GetError         bool
+		ListError        bool
+		Name             string
+		PatchError       bool
+		UpdateError      bool
+	}{
+		{ExpectedRotation: false, GetError: true, Name: "get-secret"},
+		{ExpectedRotation: false, UpdateError: true, Name: "update-secret"},
+		{ExpectedRotation: true, ListError: true, Name: "list-policy"},
+		{ExpectedRotation: true, PatchError: true, Name: "patch-policy"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(
+			test.Name,
+			func(t *testing.T) {
+				t.Parallel()
+				encryptionSecret := generateSecret()
+				originalKey := encryptionSecret.Data["key"]
+				r := getReconciler(encryptionSecret)
+				erroringClient := erroringFakeClient{
+					Client:      r.Client,
+					GetError:    test.GetError,
+					ListError:   test.ListError,
+					PatchError:  test.PatchError,
+					UpdateError: test.UpdateError,
+				}
+				r.Client = &erroringClient
+
+				secretID := types.NamespacedName{Namespace: clusterName, Name: propagator.EncryptionKeySecret}
+				request := ctrl.Request{NamespacedName: secretID}
+				result, err := r.Reconcile(context.TODO(), request)
+
+				if !test.ExpectedRotation {
+					Expect(err).ShouldNot(BeNil())
+					Expect(result.RequeueAfter).Should(Equal(time.Duration(0)))
+				} else {
+					Expect(err).Should(BeNil())
+					Expect(result.RequeueAfter).ShouldNot(Equal(time.Duration(0)))
+				}
+
+				Expect(result.Requeue).To(BeFalse())
+
+				// Revert back the fake client to verify the secret and that no policy updates were triggered
+				r.Client = erroringClient.Client
+
+				err = r.Get(context.TODO(), client.ObjectKeyFromObject(encryptionSecret), encryptionSecret)
+				Expect(err).Should(BeNil())
+
+				if test.ExpectedRotation {
+					Expect(bytes.Equal(originalKey, encryptionSecret.Data["key"])).Should(BeFalse())
+				} else {
+					Expect(bytes.Equal(originalKey, encryptionSecret.Data["key"])).Should(BeTrue())
+				}
+
+				// Revert back the fake client to verify no policy updates were triggered
+				r.Client = erroringClient.Client
+				assertNoTriggerUpdate(r)
+			},
+		)
+	}
+}

--- a/controllers/propagator/policy_controller.go
+++ b/controllers/propagator/policy_controller.go
@@ -77,9 +77,8 @@ var _ reconcile.Reconciler = &PolicyReconciler{}
 // PolicyReconciler reconciles a Policy object
 type PolicyReconciler struct {
 	client.Client
-	encryptionKeyCache EncryptionKeyCache
-	Scheme             *runtime.Scheme
-	Recorder           record.EventRecorder
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 // Reconcile reads that state of the cluster for a Policy object and makes changes based on the state read

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -102,6 +102,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resourceNames:
+  - policy-encryption-key
+  resources:
+  - secrets
+  verbs:
+  - get
+  - update
+  - watch
+- apiGroups:
   - policy.open-cluster-management.io
   resources:
   - placementbindings

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -61,6 +61,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resourceNames:
+  - policy-encryption-key
+  resources:
+  - secrets
+  verbs:
+  - get
+  - update
+  - watch
+- apiGroups:
   - policy.open-cluster-management.io
   resources:
   - placementbindings

--- a/main.go
+++ b/main.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
@@ -34,6 +36,7 @@ import (
 	policyv1 "github.com/stolostron/governance-policy-propagator/api/v1"
 	policyv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
 	automationctrl "github.com/stolostron/governance-policy-propagator/controllers/automation"
+	encryptionkeysctrl "github.com/stolostron/governance-policy-propagator/controllers/encryptionkeys"
 	metricsctrl "github.com/stolostron/governance-policy-propagator/controllers/policymetrics"
 	policysetctrl "github.com/stolostron/governance-policy-propagator/controllers/policyset"
 	propagatorctrl "github.com/stolostron/governance-policy-propagator/controllers/propagator"
@@ -71,12 +74,25 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var keyRotationDays, keyRotationMaxConcurrency uint
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8383", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.UintVar(
+		&keyRotationDays,
+		"encryption-key-rotation",
+		30,
+		"The number of days until the policy encryption key is rotated",
+	)
+	flag.UintVar(
+		&keyRotationMaxConcurrency,
+		"key-rotation-max-concurrency",
+		10,
+		"The maximum number of concurrent reconciles for the policy-encryption-keys controller",
+	)
 
 	opts := zap.Options{
 		Development: true,
@@ -88,6 +104,16 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	printVersion()
+
+	if keyRotationDays < 1 {
+		log.Info("the encryption-key-rotation flag must be greater than 0")
+		os.Exit(1)
+	}
+
+	if keyRotationMaxConcurrency < 1 {
+		log.Info("the key-rotation-max-concurrency flag must be greater than 0")
+		os.Exit(1)
+	}
 
 	namespace, err := getWatchNamespace()
 	if err != nil {
@@ -120,6 +146,18 @@ func main() {
 		}
 	}
 
+	// Set a field selector so that a watch on secrets will be limited to just the secret with the policy template
+	// encryption key.
+	newCacheFunc := cache.BuilderWithOptions(
+		cache.Options{
+			SelectorsByObject: cache.SelectorsByObject{
+				&corev1.Secret{}: {
+					Field: fields.SelectorFromSet(fields.Set{"metadata.name": propagatorctrl.EncryptionKeySecret}),
+				},
+			},
+		},
+	)
+
 	// Set default manager options
 	options := ctrl.Options{
 		Namespace:              namespace,
@@ -128,6 +166,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "policy-propagator.open-cluster-management.io",
+		NewCache:               newCacheFunc,
 	}
 
 	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)
@@ -184,6 +223,17 @@ func main() {
 		log.Error(err, "Unable to create controller", "controller", policysetctrl.ControllerName)
 		os.Exit(1)
 	}
+
+	if err = (&encryptionkeysctrl.EncryptionKeysReconciler{
+		Client:                  mgr.GetClient(),
+		KeyRotationDays:         keyRotationDays,
+		MaxConcurrentReconciles: keyRotationMaxConcurrency,
+		Scheme:                  mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		log.Error(err, "Unable to create controller", "controller", encryptionkeysctrl.ControllerName)
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/test/e2e/case12_encryptionkeys_controller_test.go
+++ b/test/e2e/case12_encryptionkeys_controller_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/stolostron/governance-policy-propagator/test/utils"
+)
+
+const (
+	EncryptionKeySecret     = "policy-encryption-key"
+	LastRotatedAnnotation   = "policy.open-cluster-management.io/last-rotated"
+	RootPolicyLabel         = "policy.open-cluster-management.io/root-policy"
+	TriggerUpdateAnnotation = "policy.open-cluster-management.io/trigger-update"
+)
+
+var _ = Describe("Test policy encryption key rotation", func() {
+	key := bytes.Repeat([]byte{byte('A')}, 256/8)
+	keyB64 := base64.StdEncoding.EncodeToString(key)
+	previousKey := bytes.Repeat([]byte{byte('B')}, 256/8)
+
+	It("should create a some sample policies", func() {
+		policyConfigs := []struct {
+			Name        string
+			IVAnnoation string
+			RootPolicy  bool
+		}{
+			// This policy should get the triggered update annotation
+			{"policy-one", "", true},
+			{testNamespace + ".policy-one", "7cznVUq5SXEE4RMZNkGOrQ==", false},
+			{"policy-two", "", true},
+			{testNamespace + ".policy-two", "", false},
+		}
+
+		for _, policyConf := range policyConfigs {
+			annotations := map[string]interface{}{}
+			if policyConf.IVAnnoation != "" {
+				annotations[IVAnnotation] = policyConf.IVAnnoation
+			}
+
+			labels := map[string]interface{}{}
+			if !policyConf.RootPolicy {
+				labels[RootPolicyLabel] = policyConf.Name
+			}
+
+			policy := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "policy.open-cluster-management.io/v1",
+					"kind":       "Policy",
+					"metadata": map[string]interface{}{
+						"annotations": annotations,
+						"labels":      labels,
+						"name":        policyConf.Name,
+						"namespace":   testNamespace,
+					},
+					"spec": map[string]interface{}{
+						"disabled": false,
+						"policy-templates": []map[string]interface{}{
+							{"objectDefinition": map[string]interface{}{}},
+						},
+					},
+				},
+			}
+			_, err := clientHubDynamic.Resource(gvrPolicy).
+				Namespace(testNamespace).
+				Create(context.TODO(), policy, metav1.CreateOptions{})
+			Expect(err).Should(BeNil())
+		}
+	})
+
+	It("should create a "+EncryptionKeySecret+" secret that needs a rotation", func() {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        EncryptionKeySecret,
+				Namespace:   testNamespace,
+				Annotations: map[string]string{LastRotatedAnnotation: "2020-04-15T01:02:03Z"},
+			},
+			Data: map[string][]byte{"key": key, "previousKey": previousKey},
+		}
+		_, err := clientHub.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+		Expect(err).Should(BeNil())
+	})
+
+	It("should have roated the key in the "+EncryptionKeySecret+" secret", func() {
+		var secret *unstructured.Unstructured
+		Eventually(func() interface{} {
+			secret = utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrSecret,
+				EncryptionKeySecret,
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
+
+			data, ok := secret.Object["data"].(map[string]interface{})
+			if !ok {
+				return ""
+			}
+
+			currentKey, ok := data["key"].(string)
+			if !ok {
+				return ""
+			}
+
+			return currentKey
+		}, defaultTimeoutSeconds, 1).ShouldNot(Equal(keyB64))
+
+		currentPrevKey, ok := secret.Object["data"].(map[string]interface{})["previousKey"].(string)
+		Expect(ok).Should(BeTrue())
+		Expect(currentPrevKey).Should(Equal(keyB64))
+	})
+
+	It("should have triggered policies to be reprocessed", func() {
+		Eventually(func() interface{} {
+			policy := utils.GetWithTimeout(
+				clientHubDynamic,
+				gvrPolicy,
+				"policy-one",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
+
+			return strings.HasPrefix(policy.GetAnnotations()[TriggerUpdateAnnotation], "rotate-key-")
+		}, defaultTimeoutSeconds, 1).Should(BeTrue())
+
+		policy, err := clientHubDynamic.Resource(gvrPolicy).Namespace(testNamespace).Get(
+			context.TODO(), "policy-two", metav1.GetOptions{},
+		)
+		Expect(err).Should(BeNil())
+		Expect(policy.GetAnnotations()[TriggerUpdateAnnotation]).Should(Equal(""))
+	})
+
+	It("clean up", func() {
+		err := clientHub.CoreV1().Secrets(testNamespace).Delete(
+			context.TODO(), EncryptionKeySecret, metav1.DeleteOptions{},
+		)
+		Expect(err).Should(BeNil())
+
+		for _, policyName := range []string{"policy-one", "policy-two"} {
+			err = clientHubDynamic.Resource(gvrPolicy).Namespace(testNamespace).Delete(
+				context.TODO(), policyName, metav1.DeleteOptions{},
+			)
+			Expect(err).Should(BeNil())
+		}
+	})
+})

--- a/test/resources/case9_templates/case9-test-encryption-secret.yaml
+++ b/test/resources/case9_templates/case9-test-encryption-secret.yaml
@@ -5,4 +5,6 @@ data:
 metadata:
   labels:
     cluster.open-cluster-management.io/backup: policy
+  annotations:
+    policy.open-cluster-management.io/disable-rotation: 'true'
   name: policy-encryption-key


### PR DESCRIPTION
This controller is responsible for rotating encryption keys in the
policy-encryption-key secrets for each managed cluster.

This adds a watch to such secrets, which inherently caches these values
so the custom encryption key cache for the main controller was removed.

Resolves:
https://github.com/stolostron/backlog/issues/18723