### PR TITLE
Fix panic on nil annotations

### DIFF
--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -912,6 +912,11 @@ func (r *PolicyReconciler) processTemplates(
 
 	annotations := replicatedPlc.GetAnnotations()
 
+	// handle possible nil map
+	if len(annotations) == 0 {
+		annotations = make(map[string]string)
+	}
+
 	// if disable-templates annotations exists and is true, then exit without processing templates
 	if disable, ok := annotations["policy.open-cluster-management.io/disable-templates"]; ok {
 		if boolDisable, err := strconv.ParseBool(disable); err == nil && boolDisable {


### PR DESCRIPTION
If a policy using encryption was created without any annotations (which
is tricky to do - kubectl automatically adds some), then the propagator
will panic when trying to write the initialization vector to the nil
map.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>