### PR TITLE
Update logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
 	github.com/prometheus/client_golang v1.12.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-template-utils/v2 v2.2.2
 	k8s.io/api v0.23.3
 	k8s.io/apimachinery v0.23.3
@@ -52,7 +53,6 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect

--- a/main.go
+++ b/main.go
@@ -94,9 +94,7 @@ func main() {
 		"The maximum number of concurrent reconciles for the policy-encryption-keys controller",
 	)
 
-	opts := zap.Options{
-		Development: true,
-	}
+	opts := zap.Options{}
 
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -71,33 +72,34 @@ func init() {
 }
 
 func main() {
+	opts := zap.Options{}
+	opts.BindFlags(flag.CommandLine)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
 	var keyRotationDays, keyRotationMaxConcurrency uint
 
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8383", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
+	pflag.StringVar(&metricsAddr, "metrics-bind-address", ":8383", "The address the metric endpoint binds to.")
+	pflag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	pflag.BoolVar(&enableLeaderElection, "leader-elect", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.UintVar(
+	pflag.UintVar(
 		&keyRotationDays,
 		"encryption-key-rotation",
 		30,
 		"The number of days until the policy encryption key is rotated",
 	)
-	flag.UintVar(
+	pflag.UintVar(
 		&keyRotationMaxConcurrency,
 		"key-rotation-max-concurrency",
 		10,
 		"The maximum number of concurrent reconciles for the policy-encryption-keys controller",
 	)
 
-	opts := zap.Options{}
-
-	opts.BindFlags(flag.CommandLine)
-	flag.Parse()
+	pflag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 


### PR DESCRIPTION
- Use `pflag` instead of `flag` as other controllers do
- Remove Development mode as the default:
  > - Development Mode defaults:
  >    encoder=consoleEncoder, logLevel=Debug, stackTraceLevel=Warn
  > - Production Mode defaults:
  >    encoder=jsonEncoder, logLevel=Info, stackTraceLevel=Error