### PR TITLE
Add a statusMessage to the PolicySet status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ kind-deploy-controller: manifests
 	kubectl create ns $(KIND_NAMESPACE)
 	kubectl apply -f deploy/operator.yaml -n $(KIND_NAMESPACE)
 
-kind-deploy-controller-dev: manifests kind-deploy-controller
+kind-deploy-controller-dev: kind-deploy-controller
 	@echo Pushing image to KinD cluster
 	kind load docker-image $(REGISTRY)/$(IMG):$(TAG) --name $(KIND_NAME)
 	@echo "Patch deployment image"

--- a/api/v1beta1/policyset_types.go
+++ b/api/v1beta1/policyset_types.go
@@ -22,8 +22,9 @@ type PolicySetSpec struct {
 
 // PolicySetStatus defines the observed state of PolicySet
 type PolicySetStatus struct {
-	Placement []PolicySetStatusPlacement `json:"placement,omitempty"`
-	Compliant string                     `json:"compliant,omitempty"`
+	Placement     []PolicySetStatusPlacement `json:"placement,omitempty"`
+	Compliant     string                     `json:"compliant,omitempty"`
+	StatusMessage string                     `json:"statusMessage,omitempty"`
 }
 
 // PolicySetStatusPlacement defines a placement object for the status

--- a/deploy/crds/policy.open-cluster-management.io_policysets.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_policysets.yaml
@@ -73,6 +73,8 @@ spec:
                       type: string
                   type: object
                 type: array
+              statusMessage:
+                type: string
             type: object
         required:
         - spec

--- a/test/resources/case11_policyset_controller/case11-plcset-multistatus.yaml
+++ b/test/resources/case11_policyset_controller/case11-plcset-multistatus.yaml
@@ -1,0 +1,108 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case11-test-disabled
+spec:
+  remediationAction: inform
+  disabled: true
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-pod-case11
+        spec:
+          remediationAction: inform
+          severity: low
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: pod-that-does-not-exist
+                spec:
+                  containers:
+                    - image: nginx:1.18.0
+                      name: nginx
+                      ports:
+                        - containerPort: 80
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case11-test-message-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-pod-case11
+        spec:
+          remediationAction: inform
+          severity: low
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: pod-that-does-not-exist
+                spec:
+                  containers:
+                    - image: nginx:1.18.0
+                      name: nginx
+                      ports:
+                        - containerPort: 80
+---
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: case11-multistatus-policyset
+spec:
+  policies:
+  - case11-test-message-policy
+  - case11-does-not-exist
+  - case11-deleted-policy
+  - case11-test-disabled
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case11-multistatus-policyset-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: case11-multistatus-policyset-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: PolicySet
+  name: case11-multistatus-policyset
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: case11-multistatus-policyset-plr
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+          - managed1

--- a/test/resources/case11_policyset_controller/case11-statuscheck-1.yaml
+++ b/test/resources/case11_policyset_controller/case11-statuscheck-1.yaml
@@ -10,3 +10,4 @@ status:
   placement:
   - placementBinding: case11-test-policyset-pb
     placementRule: case11-test-policyset-plr
+  statusMessage: All policies are reporting status

--- a/test/resources/case11_policyset_controller/case11-statuscheck-2.yaml
+++ b/test/resources/case11_policyset_controller/case11-statuscheck-2.yaml
@@ -7,6 +7,8 @@ spec:
   - case11-test-policy
   - policyset-does-not-exist
 status:
+  compliant: NonCompliant
   placement:
   - placementBinding: case11-test-policyset-pb
     placementRule: case11-test-policyset-plr
+  statusMessage: "Deleted policies: policyset-does-not-exist"

--- a/test/resources/case11_policyset_controller/case11-statuscheck-3.yaml
+++ b/test/resources/case11_policyset_controller/case11-statuscheck-3.yaml
@@ -10,3 +10,4 @@ status:
   placement:
   - placementBinding: case11-test-policyset-pb
     placementRule: case11-test-policyset-plr
+  statusMessage: All policies are reporting status

--- a/test/resources/case11_policyset_controller/case11-statuscheck-4.yaml
+++ b/test/resources/case11_policyset_controller/case11-statuscheck-4.yaml
@@ -9,3 +9,4 @@ status:
   placement:
   - placementBinding: case11-test-policyset-pb
     placementRule: case11-test-policyset-plr
+  statusMessage: "Disabled policies: case11-test-policy"

--- a/test/resources/case11_policyset_controller/case11-statuscheck-5.yaml
+++ b/test/resources/case11_policyset_controller/case11-statuscheck-5.yaml
@@ -11,3 +11,4 @@ status:
   placement:
   - placementBinding: case11-test-policyset-pb
     placementRule: case11-test-policyset-plr
+  statusMessage: "Disabled policies: case11-test-policy"

--- a/test/resources/case11_policyset_controller/case11-statuscheck-6.yaml
+++ b/test/resources/case11_policyset_controller/case11-statuscheck-6.yaml
@@ -10,3 +10,4 @@ status:
   placement:
   - placementBinding: test-plcset-managed1-pb
     placementRule: test-plcset-managed1-plr
+  statusMessage: All policies are reporting status

--- a/test/resources/case11_policyset_controller/case11-statuscheck-7.yaml
+++ b/test/resources/case11_policyset_controller/case11-statuscheck-7.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: case11-multistatus-policyset
+spec:
+  policies:
+  - case11-test-message-policy
+  - case11-does-not-exist
+  - case11-deleted-policy
+  - case11-test-disabled
+status:
+  placement:
+  - placementBinding: case11-multistatus-policyset-pb
+    placementRule: case11-multistatus-policyset-plr
+  statusMessage: "Disabled policies: case11-test-disabled; No status provided while
+    policies are pending: case11-test-message-policy; Deleted policies: case11-does-not-exist,
+    case11-deleted-policy"


### PR DESCRIPTION
The PolicySet status sometimes shows the compliance status and
sometimes it doesn't.  To help understand what's going on we need a
message.  In the future we may have a pending state for policies, but
for now we just want a message in the PolicySet to explain whether the
status is unable to account for some of the policies.

Refs:
 - https://github.com/stolostron/backlog/issues/21750

Signed-off-by: Gus Parvin <gparvin@redhat.com>