### PR TITLE
Rename the module name to match upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,6 @@ IMG ?= $(shell cat COMPONENT_NAME 2> /dev/null)
 REGISTRY ?= quay.io/stolostron
 TAG ?= latest
 
-# Github host to use for checking the source tree;
-# Override this variable ue with your own value if you're working on forked repo.
-GIT_HOST ?= github.com/stolostron
-
 PWD := $(shell pwd)
 BASE_DIR := $(shell basename $(PWD))
 export PATH := $(PWD)/bin:$(PATH)
@@ -38,7 +34,6 @@ GOARCH = $(shell go env GOARCH)
 GOOS = $(shell go env GOOS)
 TESTARGS_DEFAULT := "-v"
 export TESTARGS ?= $(TESTARGS_DEFAULT)
-DEST ?= $(GOPATH)/src/$(GIT_HOST)/$(BASE_DIR)
 VERSION ?= $(shell cat COMPONENT_VERSION 2> /dev/null)
 IMAGE_NAME_AND_VERSION ?= $(REGISTRY)/$(IMG)
 # Handle KinD configuration
@@ -232,7 +227,7 @@ e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --output-dir=.
 e2e-test-coverage: e2e-test
 
 e2e-build-instrumented:
-	go test -covermode=atomic -coverpkg=$(GIT_HOST)/$(IMG)/... -c -tags e2e ./ -o build/_output/bin/$(IMG)-instrumented
+	go test -covermode=atomic -coverpkg=$(shell cat go.mod | head -1 | cut -d ' ' -f 2)/... -c -tags e2e ./ -o build/_output/bin/$(IMG)-instrumented
 
 e2e-run-instrumented:
 	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=coverage_e2e.out &>/dev/null &

--- a/PROJECT
+++ b/PROJECT
@@ -14,7 +14,7 @@ resources:
   domain: open-cluster-management.io
   group: policy
   kind: Policy
-  path: github.com/stolostron/governance-policy-propagator/api/v1
+  path: open-cluster-management.io/governance-policy-propagator/api/v1
   version: v1
 - api:
     crdVersion: v1
@@ -22,7 +22,7 @@ resources:
   domain: open-cluster-management.io
   group: policy
   kind: PlacementBinding
-  path: github.com/stolostron/governance-policy-propagator/api/v1
+  path: open-cluster-management.io/governance-policy-propagator/api/v1
   version: v1
 - api:
     crdVersion: v1
@@ -31,7 +31,7 @@ resources:
   domain: open-cluster-management.io
   group: policy
   kind: PolicyAutomation
-  path: github.com/stolostron/governance-policy-propagator/api/v1beta1
+  path: open-cluster-management.io/governance-policy-propagator/api/v1beta1
   version: v1beta1
 - api:
     crdVersion: v1
@@ -40,6 +40,6 @@ resources:
   domain: open-cluster-management.io
   group: policy
   kind: PolicySet
-  path: github.com/stolostron/governance-policy-propagator/api/v1
+  path: open-cluster-management.io/governance-policy-propagator/api/v1
   version: v1
 version: "3"

--- a/build/common/config/.golangci.yml
+++ b/build/common/config/.golangci.yml
@@ -68,7 +68,7 @@ linters-settings:
     # report about shadowed variables
     check-shadowing: false
   gci:
-    local-prefixes: github.com/stolostron/governance-policy-propagator
+    local-prefixes: open-cluster-management.io/governance-policy-propagator
   golint:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0.0

--- a/controllers/automation/PolicyAutomationPredicate.go
+++ b/controllers/automation/PolicyAutomationPredicate.go
@@ -7,7 +7,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	policyv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
+	policyv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 )
 
 // we only want to watch for pb contains policy as subjects

--- a/controllers/automation/policyMapper.go
+++ b/controllers/automation/policyMapper.go
@@ -10,8 +10,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	policyv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	policyv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 )
 
 func policyMapper(c client.Client) handler.MapFunc {

--- a/controllers/automation/policyPredicate.go
+++ b/controllers/automation/policyPredicate.go
@@ -6,7 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
 
 // we only want to watch for pb contains policy as subjects

--- a/controllers/automation/policyautomation_controller.go
+++ b/controllers/automation/policyautomation_controller.go
@@ -19,9 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	policyv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	policyv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
+	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	policyv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
 )
 
 const ControllerName string = "policy-automation"

--- a/controllers/common/ansible.go
+++ b/controllers/common/ansible.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
-	policyv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
+	policyv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 )
 
 // CreateAnsibleJob creates ansiblejob with given PolicyAutomation

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -17,7 +17,7 @@ import (
 	appsv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
 
 const (

--- a/controllers/encryptionkeys/encryptionkeys_controller.go
+++ b/controllers/encryptionkeys/encryptionkeys_controller.go
@@ -21,9 +21,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policyv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
-	"github.com/stolostron/governance-policy-propagator/controllers/propagator"
+	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+	"open-cluster-management.io/governance-policy-propagator/controllers/propagator"
 )
 
 const (

--- a/controllers/encryptionkeys/encryptionkeys_controller_test.go
+++ b/controllers/encryptionkeys/encryptionkeys_controller_test.go
@@ -25,9 +25,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	v1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
-	"github.com/stolostron/governance-policy-propagator/controllers/propagator"
+	v1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+	"open-cluster-management.io/governance-policy-propagator/controllers/propagator"
 )
 
 const (

--- a/controllers/policymetrics/policymetrics_controller.go
+++ b/controllers/policymetrics/policymetrics_controller.go
@@ -15,8 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
 )
 
 const ControllerName string = "policy-metrics"

--- a/controllers/policyset/placementBindingMapper.go
+++ b/controllers/policyset/placementBindingMapper.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
 
 func placementBindingMapper(c client.Client) handler.MapFunc {

--- a/controllers/policyset/placementBindingPredicate.go
+++ b/controllers/policyset/placementBindingPredicate.go
@@ -7,8 +7,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
 )
 
 // we only want to watch for pb contains policyset as a subject

--- a/controllers/policyset/placementDecisionMapper.go
+++ b/controllers/policyset/placementDecisionMapper.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
 
 func placementDecisionMapper(c client.Client) handler.MapFunc {

--- a/controllers/policyset/placementRuleMapper.go
+++ b/controllers/policyset/placementRuleMapper.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
 
 func placementRuleMapper(c client.Client) handler.MapFunc {

--- a/controllers/policyset/policyMapper.go
+++ b/controllers/policyset/policyMapper.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
 
 func policyMapper(c client.Client) handler.MapFunc {

--- a/controllers/policyset/policyPredicate.go
+++ b/controllers/policyset/policyPredicate.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
 
 var policyPredicateFuncs = predicate.Funcs{

--- a/controllers/policyset/policySetPredicate.go
+++ b/controllers/policyset/policySetPredicate.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	policiesv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
+	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 )
 
 var policySetPredicateFuncs = predicate.Funcs{

--- a/controllers/policyset/policyset_controller.go
+++ b/controllers/policyset/policyset_controller.go
@@ -22,9 +22,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	policyv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	policyv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
+	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	policyv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
 )
 
 const ControllerName string = "policy-set"

--- a/controllers/propagator/placementBindingMapper.go
+++ b/controllers/propagator/placementBindingMapper.go
@@ -11,8 +11,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	policiesv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 )
 
 func placementBindingMapper(c client.Client) handler.MapFunc {

--- a/controllers/propagator/placementBindingPredicate.go
+++ b/controllers/propagator/placementBindingPredicate.go
@@ -7,8 +7,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
 )
 
 // we only want to watch for pb contains policy and policyset as subjects

--- a/controllers/propagator/placementDecisionMapper.go
+++ b/controllers/propagator/placementDecisionMapper.go
@@ -12,8 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	policiesv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 )
 
 func placementDecisionMapper(c client.Client) handler.MapFunc {

--- a/controllers/propagator/placementRuleMapper.go
+++ b/controllers/propagator/placementRuleMapper.go
@@ -12,8 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	policiesv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 )
 
 func placementRuleMapper(c client.Client) handler.MapFunc {

--- a/controllers/propagator/policyMapper.go
+++ b/controllers/propagator/policyMapper.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
 )
 
 // policyMapper looks at object and returns a slice of reconcile.Request to reconcile

--- a/controllers/propagator/policySetMapper.go
+++ b/controllers/propagator/policySetMapper.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policiesv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
+	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 )
 
 func policySetMapper(c client.Client) handler.MapFunc {

--- a/controllers/propagator/policySetPredicate.go
+++ b/controllers/propagator/policySetPredicate.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	policiesv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
+	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 )
 
 // we only want to watch for policyset objects with Spec.Policies field change

--- a/controllers/propagator/policy_controller.go
+++ b/controllers/propagator/policy_controller.go
@@ -22,9 +22,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	policiesv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
 )
 
 const ControllerName string = "policy-propagator"

--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -27,9 +27,9 @@ import (
 	appsv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	policiesv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
 )
 
 const (

--- a/controllers/propagator/propagation_test.go
+++ b/controllers/propagator/propagation_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/client-go/rest"
 	appsv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
 
 func TestInitializeAttempts(t *testing.T) {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	//+kubebuilder:scaffold:imports
-	policyv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	policyv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
+	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	policyv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stolostron/governance-policy-propagator
+module open-cluster-management.io/governance-policy-propagator
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -36,14 +36,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	//+kubebuilder:scaffold:imports
-	policyv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	policyv1beta1 "github.com/stolostron/governance-policy-propagator/api/v1beta1"
-	automationctrl "github.com/stolostron/governance-policy-propagator/controllers/automation"
-	encryptionkeysctrl "github.com/stolostron/governance-policy-propagator/controllers/encryptionkeys"
-	metricsctrl "github.com/stolostron/governance-policy-propagator/controllers/policymetrics"
-	policysetctrl "github.com/stolostron/governance-policy-propagator/controllers/policyset"
-	propagatorctrl "github.com/stolostron/governance-policy-propagator/controllers/propagator"
-	"github.com/stolostron/governance-policy-propagator/version"
+	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	policyv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
+	automationctrl "open-cluster-management.io/governance-policy-propagator/controllers/automation"
+	encryptionkeysctrl "open-cluster-management.io/governance-policy-propagator/controllers/encryptionkeys"
+	metricsctrl "open-cluster-management.io/governance-policy-propagator/controllers/policymetrics"
+	policysetctrl "open-cluster-management.io/governance-policy-propagator/controllers/policyset"
+	propagatorctrl "open-cluster-management.io/governance-policy-propagator/controllers/propagator"
+	"open-cluster-management.io/governance-policy-propagator/version"
 )
 
 var (

--- a/test/e2e/case10_policyset_propagation_test.go
+++ b/test/e2e/case10_policyset_propagation_test.go
@@ -12,9 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 const (

--- a/test/e2e/case11_policyset_controller_test.go
+++ b/test/e2e/case11_policyset_controller_test.go
@@ -10,9 +10,9 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 const (

--- a/test/e2e/case12_encryptionkeys_controller_test.go
+++ b/test/e2e/case12_encryptionkeys_controller_test.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/stolostron/governance-policy-propagator/test/utils"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 const (

--- a/test/e2e/case1_propagation_test.go
+++ b/test/e2e/case1_propagation_test.go
@@ -11,9 +11,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 const (

--- a/test/e2e/case2_aggregation_test.go
+++ b/test/e2e/case2_aggregation_test.go
@@ -10,9 +10,9 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 const (

--- a/test/e2e/case3_mutation_recovery_test.go
+++ b/test/e2e/case3_mutation_recovery_test.go
@@ -10,9 +10,9 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 const (

--- a/test/e2e/case4_unexpected_policy_test.go
+++ b/test/e2e/case4_unexpected_policy_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/stolostron/governance-policy-propagator/test/utils"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 const (

--- a/test/e2e/case5_policy_automation_test.go
+++ b/test/e2e/case5_policy_automation_test.go
@@ -10,9 +10,9 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 const (

--- a/test/e2e/case6_placement_propagation_test.go
+++ b/test/e2e/case6_placement_propagation_test.go
@@ -10,9 +10,9 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 const (

--- a/test/e2e/case7_bindings_test.go
+++ b/test/e2e/case7_bindings_test.go
@@ -10,9 +10,9 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 const (

--- a/test/e2e/case8_metrics_test.go
+++ b/test/e2e/case8_metrics_test.go
@@ -9,9 +9,9 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/controllers/common"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 const (

--- a/test/e2e/case9_templates_test.go
+++ b/test/e2e/case9_templates_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/stolostron/governance-policy-propagator/test/utils"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 const (


### PR DESCRIPTION
This will significantly reduce merge conflicts when syncing upstream to
Stolostron. It will also reduce the overhead of maintaining the
difference.

Related:
https://github.com/stolostron/backlog/issues/21790