### PR TITLE
Align ManagedCluster CRD; Update APIVersion

### DIFF
--- a/test/crds/cluster.open-cluster-management.io_managedclusters.yaml
+++ b/test/crds/cluster.open-cluster-management.io_managedclusters.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: managedclusters.cluster.open-cluster-management.io
@@ -8,138 +8,194 @@ spec:
     kind: ManagedCluster
     listKind: ManagedClusterList
     plural: managedclusters
+    shortNames:
+      - mcl
+      - mcls
     singular: managedcluster
-  scope: "Cluster"
-  subresources:
-    status: {}
+  scope: Cluster
   preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      description: "ManagedCluster represents the desired state and current status
-        of managed cluster. ManagedCluster is a cluster scoped resource. The name
-        is the cluster UID. \n The cluster join process follows a double opt-in process:
-        \n 1. agent on managed cluster creates CSR on hub with cluster UID and agent
-        name. 2. agent on managed cluster creates ManagedCluster on hub. 3. cluster
-        admin on hub approves the CSR for the ManagedCluster's UID and agent name.
-        4. cluster admin sets spec.acceptClient of ManagedCluster to true. 5. cluster
-        admin on managed cluster creates credential of kubeconfig to hub. \n Once
-        the hub creates the cluster namespace, the Klusterlet agent on the Managed
-        Cluster pushes the credential to the hub to use against the managed cluster's
-        kube-apiserver."
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.hubAcceptsClient
+          name: Hub Accepted
+          type: boolean
+        - jsonPath: .spec.managedClusterClientConfigs[*].url
+          name: Managed Cluster URLs
           type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        - jsonPath: .status.conditions[?(@.type=="ManagedClusterJoined")].status
+          name: Joined
           type: string
-        metadata:
-          type: object
-        spec:
-          description: Spec represents a desired configuration for the agent on the
-            managed cluster.
+        - jsonPath: .status.conditions[?(@.type=="ManagedClusterConditionAvailable")].status
+          name: Available
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: "ManagedCluster represents the desired state and current status of managed cluster. ManagedCluster is a cluster scoped resource. The name is the cluster UID. \n The cluster join process follows a double opt-in process: \n 1. Agent on managed cluster creates CSR on hub with cluster UID and agent name. 2. Agent on managed cluster creates ManagedCluster on hub. 3. Cluster admin on hub approves the CSR for UID and agent name of the ManagedCluster. 4. Cluster admin sets spec.acceptClient of ManagedCluster to true. 5. Cluster admin on managed cluster creates credential of kubeconfig to hub. \n Once the hub creates the cluster namespace, the Klusterlet agent on the ManagedCluster pushes the credential to the hub to use against the kube-apiserver of the ManagedCluster."
           type: object
           properties:
-            hubAcceptsClient:
-              description: hubAcceptsClient represents that hub accepts the join of
-                Klusterlet agent on the managed cluster to the hub. The default value
-                is false, and can only be set true when the user on hub has an RBAC
-                rule to UPDATE on the virtual subresource of managedclusters/accept.
-                When the value is set true, a namespace whose name is same as the
-                name of ManagedCluster is created on hub representing the managed
-                cluster, also role/rolebinding is created on the namespace to grant
-                the permision of access from agent on managed cluster. When the value
-                is set false, the namespace representing the managed cluster is deleted.
-              type: boolean
-            leaseDurationSeconds:
-              description: LeaseDurationSeconds is used to coordinate the lease update
-                time of Klusterlet agents on the managed cluster. If its value is
-                zero, the Klusterlet agent will update its lease every 60s by default
-              type: integer
-              format: int32
-            managedClusterClientConfigs:
-              description: ManagedClusterClientConfigs represents a list of the apiserver
-                address of the managed cluster. If it is empty, managed cluster has
-                no accessible address to be visited from hub.
-              type: array
-              items:
-                description: ClientConfig represents the apiserver address of the
-                  managed cluster. TODO include credential to connect to managed cluster
-                  kube-apiserver
-                type: object
-                properties:
-                  caBundle:
-                    description: CABundle is the ca bundle to connect to apiserver
-                      of the managed cluster. System certs are used if it is not set.
-                    type: string
-                    format: byte
-                  url:
-                    description: URL is the url of apiserver endpoint of the managed
-                      cluster.
-                    type: string
-        status:
-          description: Status represents the current status of joined managed cluster
-          type: object
-          properties:
-            allocatable:
-              description: Allocatable represents the total allocatable resources
-                on the managed cluster.
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
               type: object
-              additionalProperties:
-                type: string
-            capacity:
-              description: Capacity represents the total resource capacity from all
-                nodeStatuses on the managed cluster.
-              type: object
-              additionalProperties:
-                type: string
-            conditions:
-              description: Conditions contains the different condition statuses for
-                this managed cluster.
-              type: array
-              items:
-                description: StatusCondition contains condition information for a
-                  managed cluster.
-                type: object
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition
-                      changed from one status to another.
-                    type: string
-                    format: date-time
-                  message:
-                    description: Message is a human-readable message indicating details
-                      about the last status change.
-                    type: string
-                  reason:
-                    description: Reason is a (brief) reason for the condition's last
-                      status change.
-                    type: string
-                  status:
-                    description: Status is the status of the condition. One of True,
-                      False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the cluster condition.
-                    type: string
-            version:
-              description: Version represents the kubernetes version of the managed
-                cluster.
+            spec:
+              description: Spec represents a desired configuration for the agent on the managed cluster.
               type: object
               properties:
-                kubernetes:
-                  description: Kubernetes is the kubernetes version of managed cluster.
-                  type: string
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
+                hubAcceptsClient:
+                  description: hubAcceptsClient represents that hub accepts the joining of Klusterlet agent on the managed cluster with the hub. The default value is false, and can only be set true when the user on hub has an RBAC rule to UPDATE on the virtual subresource of managedclusters/accept. When the value is set true, a namespace whose name is the same as the name of ManagedCluster is created on the hub. This namespace represents the managed cluster, also role/rolebinding is created on the namespace to grant the permision of access from the agent on the managed cluster. When the value is set to false, the namespace representing the managed cluster is deleted.
+                  type: boolean
+                leaseDurationSeconds:
+                  description: LeaseDurationSeconds is used to coordinate the lease update time of Klusterlet agents on the managed cluster. If its value is zero, the Klusterlet agent will update its lease every 60 seconds by default
+                  type: integer
+                  format: int32
+                  default: 60
+                managedClusterClientConfigs:
+                  description: ManagedClusterClientConfigs represents a list of the apiserver address of the managed cluster. If it is empty, the managed cluster has no accessible address for the hub to connect with it.
+                  type: array
+                  items:
+                    description: ClientConfig represents the apiserver address of the managed cluster. TODO include credential to connect to managed cluster kube-apiserver
+                    type: object
+                    properties:
+                      caBundle:
+                        description: CABundle is the ca bundle to connect to apiserver of the managed cluster. System certs are used if it is not set.
+                        type: string
+                        format: byte
+                      url:
+                        description: URL is the URL of apiserver endpoint of the managed cluster.
+                        type: string
+                taints:
+                  description: Taints is a property of managed cluster that allow the cluster to be repelled when scheduling. Taints, including 'ManagedClusterUnavailable' and 'ManagedClusterUnreachable', can not be added/removed by agent running on the managed cluster; while it's fine to add/remove other taints from either hub cluser or managed cluster.
+                  type: array
+                  items:
+                    description: The managed cluster this Taint is attached to has the "effect" on any placement that does not tolerate the Taint.
+                    type: object
+                    required:
+                      - effect
+                      - key
+                    properties:
+                      effect:
+                        description: Effect indicates the effect of the taint on placements that do not tolerate the taint. Valid effects are NoSelect, PreferNoSelect and NoSelectIfNew.
+                        type: string
+                        enum:
+                          - NoSelect
+                          - PreferNoSelect
+                          - NoSelectIfNew
+                      key:
+                        description: Key is the taint key applied to a cluster. e.g. bar or foo.example.com/bar. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      timeAdded:
+                        description: TimeAdded represents the time at which the taint was added.
+                        type: string
+                        format: date-time
+                        nullable: true
+                      value:
+                        description: Value is the taint value corresponding to the taint key.
+                        type: string
+                        maxLength: 1024
+            status:
+              description: Status represents the current status of joined managed cluster
+              type: object
+              properties:
+                allocatable:
+                  description: Allocatable represents the total allocatable resources on the managed cluster.
+                  type: object
+                  additionalProperties:
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    x-kubernetes-int-or-string: true
+                capacity:
+                  description: Capacity represents the total resource capacity from all nodeStatuses on the managed cluster.
+                  type: object
+                  additionalProperties:
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    x-kubernetes-int-or-string: true
+                clusterClaims:
+                  description: ClusterClaims represents cluster information that a managed cluster claims, for example a unique cluster identifier (id.k8s.io) and kubernetes version (kubeversion.open-cluster-management.io). They are written from the managed cluster. The set of claims is not uniform across a fleet, some claims can be vendor or version specific and may not be included from all managed clusters.
+                  type: array
+                  items:
+                    description: ManagedClusterClaim represents a ClusterClaim collected from a managed cluster.
+                    type: object
+                    properties:
+                      name:
+                        description: Name is the name of a ClusterClaim resource on managed cluster. It's a well known or customized name to identify the claim.
+                        type: string
+                        maxLength: 253
+                        minLength: 1
+                      value:
+                        description: Value is a claim-dependent string
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                conditions:
+                  description: Conditions contains the different condition statuses for this managed cluster.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                version:
+                  description: Version represents the kubernetes version of the managed cluster.
+                  type: object
+                  properties:
+                    kubernetes:
+                      description: Kubernetes is the kubernetes version of managed cluster.
+                      type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
This ManagedCluster CRD matches the version in use in `go.mod` for `open-cluster-management.io/api`.