### PR TITLE
[release-2.3] Set Kind version

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -29,7 +29,7 @@ jobs:
         # KinD tags: https://hub.docker.com/r/kindest/node/tags
         kind:
           - 'v1.18.15'
-          - 'latest'
+          - 'v1.21.10'
     name: KinD tests
     steps:
     - name: Checkout Governance Policy Propagator


### PR DESCRIPTION
The `v1beta1` CRD is removed in `v1.22`, so the ManagedCluster will fail to deploy.