### PR TITLE
[release-2.6] Prevent panic from unexpected label values

### DIFF
--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -5,6 +5,9 @@ package common
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/avast/retry-go/v3"
@@ -26,6 +29,8 @@ const (
 	ClusterNamespaceLabel string = APIGroup + "/cluster-namespace"
 	RootPolicyLabel       string = APIGroup + "/root-policy"
 )
+
+var ErrInvalidLabelValue = errors.New("unexpected format of label value")
 
 // IsInClusterNamespace check if policy is in cluster namespace
 func IsInClusterNamespace(ns string, allClusters []clusterv1.ManagedCluster) bool {
@@ -200,4 +205,16 @@ func GetNumWorkers(listLength int, concurrencyPerPolicy int) int {
 	}
 
 	return numWorkers
+}
+
+func ParseRootPolicyLabel(rootPlc string) (name, namespace string, err error) {
+	rootSplit := strings.Split(rootPlc, ".")
+	if len(rootSplit) != 2 {
+		err = fmt.Errorf("required exactly one `.` in value of label `%v`: %w",
+			RootPolicyLabel, ErrInvalidLabelValue)
+
+		return "", "", err
+	}
+
+	return rootSplit[1], rootSplit[0], nil
 }

--- a/controllers/common/common_test.go
+++ b/controllers/common/common_test.go
@@ -1,0 +1,30 @@
+package common
+
+import "testing"
+
+func TestParseRootPolicyLabel(t *testing.T) {
+	tests := map[string]struct {
+		name      string
+		namespace string
+		shouldErr bool
+	}{
+		"foobar":   {"", "", true},
+		"foo.bar":  {"bar", "foo", false},
+		"fo.ob.ar": {"", "", true},
+	}
+
+	for input, expected := range tests {
+		t.Run(input, func(t *testing.T) {
+			name, namespace, err := ParseRootPolicyLabel(input)
+			if (err != nil) != expected.shouldErr {
+				t.Fatal("expected error, got nil")
+			}
+			if name != expected.name {
+				t.Fatalf("expected name '%v', got '%v'", expected.name, name)
+			}
+			if namespace != expected.namespace {
+				t.Fatalf("expected namespace '%v', got '%v'", expected.namespace, namespace)
+			}
+		})
+	}
+}

--- a/controllers/encryptionkeys/encryptionkeys_controller.go
+++ b/controllers/encryptionkeys/encryptionkeys_controller.go
@@ -273,14 +273,22 @@ func (r *EncryptionKeysReconciler) triggerTemplateUpdate(
 			continue
 		}
 
+		name, namespace, err := common.ParseRootPolicyLabel(rootPlcName)
+		if err != nil {
+			log.Error(err, "Unable to parse name and namespace of root policy, ignoring this replicated policy",
+				"rootPlcName", rootPlcName)
+
+			continue
+		}
+
 		rootPolicy := &policyv1.Policy{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: strings.Split(rootPlcName, ".")[0],
-				Name:      strings.Split(rootPlcName, ".")[1],
+				Namespace: namespace,
+				Name:      name,
 			},
 		}
 
-		err := retry.Do(
+		err = retry.Do(
 			func() error {
 				return r.Patch(ctx, rootPolicy, client.RawPatch(types.MergePatchType, patch))
 			},

--- a/controllers/policyset/policyset_controller.go
+++ b/controllers/policyset/policyset_controller.go
@@ -139,7 +139,12 @@ func (r *PolicySetReconciler) processPolicySet(ctx context.Context, plcSet *poli
 			if errors.IsNotFound(err) {
 				errMessage = string(childPlcName) + " not found"
 			} else {
-				errMessage = strings.Split(err.Error(), "Policy.policy.open-cluster-management.io ")[1]
+				split := strings.Split(err.Error(), "Policy.policy.open-cluster-management.io ")
+				if len(split) < 2 {
+					errMessage = err.Error()
+				} else {
+					errMessage = split[1]
+				}
 			}
 
 			log.V(2).Info(errMessage)

--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -562,8 +562,9 @@ func (r *PolicyReconciler) handleRootPolicy(instance *policiesv1.Policy) error {
 			log.Info(
 				"Setting the policy to noncompliant since the replication failed", "cluster", clusterNsName,
 			)
-			// The string split is safe since the namespace and name cannot have slashes in them
-			// since they must be DNS compliant names
+			// Since the name and namespace are DNS compliant names, they do not have any slashes,
+			// so this split will always give us what we expect, and not split in the wrong place.
+			// Note: this split is guaranteed to have 2 elements by the `handleDecision` implementation
 			clusterNsNameSl := strings.Split(clusterNsName, "/")
 
 			status = append(status, &policiesv1.CompliancePerClusterStatus{


### PR DESCRIPTION
There were two places where the root-policy label was assumed to have one `.` in it, since that's how the propagator sets the label. But if a user created a Policy with that label, it doesn't necessarily have that character, so the propagator could panic trying to access a value out of the range of the slice.

There was another spot that used a similar split, but that one is safe, for now.

Refs:
 - https://github.com/stolostron/backlog/issues/26592

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>
(cherry picked from commit 2914c006d17e26c46cbaf42f74585971f58a5554)