### PR TITLE
[release-2.4] Prevent panic from unexpected label values

### DIFF
--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -4,15 +4,23 @@
 package common
 
 import (
+	"errors"
+	"fmt"
+	"strings"
+
 	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
-const APIGroup string = "policy.open-cluster-management.io"
-const ClusterNameLabel string = APIGroup + "/cluster-name"
-const ClusterNamespaceLabel string = APIGroup + "/cluster-namespace"
-const RootPolicyLabel string = APIGroup + "/root-policy"
+const (
+	APIGroup              string = "policy.open-cluster-management.io"
+	ClusterNameLabel      string = APIGroup + "/cluster-name"
+	ClusterNamespaceLabel string = APIGroup + "/cluster-namespace"
+	RootPolicyLabel       string = APIGroup + "/root-policy"
+)
+
+var ErrInvalidLabelValue = errors.New("unexpected format of label value")
 
 // IsInClusterNamespace check if policy is in cluster namespace
 func IsInClusterNamespace(ns string, allClusters []clusterv1.ManagedCluster) bool {
@@ -65,4 +73,16 @@ func FindNonCompliantClustersForPolicy(plc *policiesv1.Policy) []string {
 		}
 	}
 	return clusterList
+}
+
+func ParseRootPolicyLabel(rootPlc string) (name, namespace string, err error) {
+	rootSplit := strings.Split(rootPlc, ".")
+	if len(rootSplit) != 2 {
+		err = fmt.Errorf("required exactly one `.` in value of label `%v`: %w",
+			RootPolicyLabel, ErrInvalidLabelValue)
+
+		return "", "", err
+	}
+
+	return rootSplit[1], rootSplit[0], nil
 }

--- a/controllers/common/common_test.go
+++ b/controllers/common/common_test.go
@@ -1,0 +1,30 @@
+package common
+
+import "testing"
+
+func TestParseRootPolicyLabel(t *testing.T) {
+	tests := map[string]struct {
+		name      string
+		namespace string
+		shouldErr bool
+	}{
+		"foobar":   {"", "", true},
+		"foo.bar":  {"bar", "foo", false},
+		"fo.ob.ar": {"", "", true},
+	}
+
+	for input, expected := range tests {
+		t.Run(input, func(t *testing.T) {
+			name, namespace, err := ParseRootPolicyLabel(input)
+			if (err != nil) != expected.shouldErr {
+				t.Fatal("expected error, got nil")
+			}
+			if name != expected.name {
+				t.Fatalf("expected name '%v', got '%v'", expected.name, name)
+			}
+			if namespace != expected.namespace {
+				t.Fatalf("expected namespace '%v', got '%v'", expected.namespace, namespace)
+			}
+		})
+	}
+}

--- a/controllers/propagator/policyMapper.go
+++ b/controllers/propagator/policyMapper.go
@@ -4,8 +4,6 @@
 package propagator
 
 import (
-	"strings"
-
 	"github.com/stolostron/governance-policy-propagator/controllers/common"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,8 +22,16 @@ func policyMapper(c client.Client) handler.MapFunc {
 			// policy.open-cluster-management.io/root-policy exists, should be a replicated policy
 			log.Info("Found reconciliation request from replicated policy...", "Namespace", object.GetNamespace(),
 				"Name", object.GetName())
-			name = strings.Split(rootPlcName, ".")[1]
-			namespace = strings.Split(rootPlcName, ".")[0]
+
+			var err error
+
+			name, namespace, err = common.ParseRootPolicyLabel(rootPlcName)
+			if err != nil {
+				log.Error(err, "Unable to parse name and namespace of root policy, ignoring replicated policy",
+					"rootPlcName", rootPlcName)
+
+				return nil
+			}
 		} else {
 			// policy.open-cluster-management.io/root-policy doesn't exist, should be a root policy
 			log.Info("Found reconciliation request from root policy...", "Namespace", object.GetNamespace(),


### PR DESCRIPTION
This is a backport of 2914c006d17e26c46cbaf42f74585971f58a5554. The root policy label can not be assumed to have exactly 1 `.`, and in the case where that character wasn't present at all, the controller would panic and crash.

Refs:
 - https://github.com/stolostron/backlog/issues/26592

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>