### PR TITLE
[release-2.6] Requeue root policy when some clusters fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ e2e-build-instrumented:
 
 .PHONY: e2e-run-instrumented
 e2e-run-instrumented: e2e-build-instrumented
-	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=coverage_e2e.out &>build/_output/controller.log &
+	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" CONTROLLER_CONFIG_REQUEUE_ERROR_DELAY="1" ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=coverage_e2e.out &>build/_output/controller.log &
 
 .PHONY: e2e-stop-instrumented
 e2e-stop-instrumented:

--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -631,6 +631,18 @@ func (r *PolicyReconciler) handleRootPolicy(instance *policiesv1.Policy) error {
 		return err
 	}
 
+	if len(failedClusters) != 0 {
+		failedNS := make([]string, 0)
+
+		for decision, isTrue := range failedClusters {
+			if isTrue {
+				failedNS = append(failedNS, decision)
+			}
+		}
+
+		return errors.New("failed to handle cluster namespaces: " + strings.Join(failedNS, ", "))
+	}
+
 	log.Info("Reconciliation complete")
 
 	return nil

--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -37,6 +37,8 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "governance-policy-propagator"
+            - name: CONTROLLER_CONFIG_REQUEUE_ERROR_DELAY
+              value: "1"
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -271,6 +271,8 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: governance-policy-propagator
+        - name: CONTROLLER_CONFIG_REQUEUE_ERROR_DELAY
+          value: "1"
         image: quay.io/stolostron/governance-policy-propagator:latest
         imagePullPolicy: Always
         name: governance-policy-propagator

--- a/test/e2e/case6_placement_propagation_test.go
+++ b/test/e2e/case6_placement_propagation_test.go
@@ -587,7 +587,7 @@ var _ = Describe("Test policy propagation", func() {
 
 			By("Verifying that the policy is now replicated")
 			pol := utils.GetWithTimeout(clientHubDynamic, gvrPolicy, testNamespace+"."+case6PolicyName,
-				"test6-extra", true, defaultTimeoutSeconds)
+				"test6-extra", true, defaultTimeoutSeconds*4)
 			Expect(pol).NotTo(BeNil())
 		})
 		AfterAll(func() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -37,6 +37,7 @@ var (
 	gvrPlacementDecision  schema.GroupVersionResource
 	gvrSecret             schema.GroupVersionResource
 	gvrAnsibleJob         schema.GroupVersionResource
+	gvrNamespace          schema.GroupVersionResource
 	defaultTimeoutSeconds int
 	defaultImageRegistry  string
 )
@@ -78,6 +79,9 @@ var _ = BeforeSuite(func() {
 	}
 	gvrAnsibleJob = schema.GroupVersionResource{
 		Group: "tower.ansible.com", Version: "v1alpha1", Resource: "ansiblejobs",
+	}
+	gvrNamespace = schema.GroupVersionResource{
+		Group: "", Version: "v1", Resource: "namespaces",
 	}
 	clientHub = NewKubeClient("", "", "")
 	clientHubDynamic = NewKubeClientDynamic("", "", "")

--- a/test/resources/case6_placement_propagation/extra-cluster.yaml
+++ b/test/resources/case6_placement_propagation/extra-cluster.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test6-extra
+  finalizers:
+    - propagator-test.io/hold
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cloud: auto-detect
+    name: test6-extra
+    vendor: auto-detect
+  name: test6-extra
+spec: {}


### PR DESCRIPTION
Previously, in certain error cases, the cluster would be marked as non- compliant, but the replicated policy would never be created. Now, these errors result in the root policy bein properly requeued, with an error listing which clusters failed.

Refs:
 - https://issues.redhat.com/browse/ACM-4606

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>
(cherry picked from commit a6681963700046812607ffab860099fde6c00b90)

For https://issues.redhat.com/browse/ACM-4710

Also for https://issues.redhat.com/browse/ACM-5310