### PR TITLE
Manual cherry-pick Add webhook for limit 64 char name+np

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -108,7 +108,15 @@ jobs:
       run: |
         make e2e-debug
 
+    - name: E2E Tests for Webhook
+      run: |
+        make webhook
+        make build-images
+        make kind-deploy-controller-dev
+        make e2e-test-webhook
+
     - name: Clean up cluster
       if: ${{ always() }}
       run: |
         make kind-delete-cluster
+        

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -119,4 +119,3 @@ jobs:
       if: ${{ always() }}
       run: |
         make kind-delete-cluster
-        

--- a/Makefile
+++ b/Makefile
@@ -213,10 +213,20 @@ kustomize: ## Download kustomize locally if necessary.
 GINKGO = $(LOCAL_BIN)/ginkgo
 
 .PHONY: kind-bootstrap-cluster
-kind-bootstrap-cluster: kind-create-cluster install-crds kind-deploy-controller install-resources
+kind-bootstrap-cluster: kind-create-cluster install-crds webhook kind-deploy-controller install-resources
 
 .PHONY: kind-bootstrap-cluster-dev
 kind-bootstrap-cluster-dev: kind-create-cluster install-crds install-resources
+
+webhook:
+	-kubectl create ns $(KIND_NAMESPACE)
+	@echo installing cert-manager
+	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+	@echo "wait until pods are up"
+	kubectl wait deployment -n cert-manager cert-manager --for condition=Available=True --timeout=90s
+	kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance=cert-manager -n cert-manager --timeout=30s 
+	sed 's/namespace: open-cluster-management/namespace: $(KIND_NAMESPACE)/g' deploy/webhook.yaml | kubectl apply -f-
+	
 
 .PHONY: kind-deploy-controller
 kind-deploy-controller: manifests
@@ -280,7 +290,7 @@ e2e-dependencies:
 
 .PHONY: e2e-test
 e2e-test: e2e-dependencies
-	$(GINKGO) -v --fail-fast $(E2E_TEST_ARGS) test/e2e
+	$(GINKGO) -v --fail-fast $(E2E_TEST_ARGS) --label-filter="!webhook" test/e2e
 
 .PHONY: e2e-test-coverage
 e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --output-dir=.
@@ -297,6 +307,9 @@ e2e-run-instrumented: e2e-build-instrumented
 .PHONY: e2e-stop-instrumented
 e2e-stop-instrumented:
 	ps -ef | grep '$(IMG)' | grep -v grep | awk '{print $$2}' | xargs kill
+
+e2e-test-webhook:
+	$(GINKGO) -v --fail-fast --label-filter="webhook" test/e2e 
 
 .PHONY: e2e-debug
 e2e-debug:

--- a/PROJECT
+++ b/PROJECT
@@ -15,6 +15,9 @@ resources:
   group: policy
   kind: Policy
   path: open-cluster-management.io/governance-policy-propagator/api/v1
+  webhooks:
+    validation: true
+    webhookVersion: v1
   version: v1
 - api:
     crdVersion: v1

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ make e2e-dependencies
 make e2e-test
 ```
 
+### How to run webhook locally
+
+```bash
+--enable-webhooks=true
+```
+
+> **Limit**: If you want to run the webhook locally, you need to generate certificates and place them in `/tmp/k8s-webhook-server/serving-certs/tls.{crt,key}`. If you’re not running a local API server, you’ll also need to figure out how to proxy traffic from the remote cluster to your local webhook server. For this reason, Kubebuilder generally recommends disabling webhooks when doing your local code-run-test cycle. To disable it, please supply the `--enable-webhooks=false` argument when running the controller.
+> For more information, visit https://book.kubebuilder.io/cronjob-tutorial/running.html
+
 ### Clean up
 ```
 make kind-delete-cluster
@@ -83,6 +92,3 @@ The following environment variables can be set to configure the controller:
 
 - The `governance-policy-propagator` is part of the `open-cluster-management` community. For more information, visit: [open-cluster-management.io](https://open-cluster-management.io).
 
-<!---
-Date: 01/27/2023
--->

--- a/api/v1/policy_webhook.go
+++ b/api/v1/policy_webhook.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package v1
+
+import (
+	"errors"
+	"unicode/utf8"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var (
+	// log is for logging in this package.
+	policylog = logf.Log.WithName("policy-validating-webhook")
+	errName   = errors.New("the combined length of the policy namespace and name " +
+		"<namespace>.<name> cannot exceed 63 characters")
+)
+
+func (r *Policy) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/validate-policy-open-cluster-management-io-v1-policy,mutating=false,failurePolicy=Ignore,sideEffects=None,groups=policy.open-cluster-management.io,resources=policies,verbs=create,versions=v1,name=policy.open-cluster-management.io.webhook,admissionReviewVersions=v1
+
+var _ webhook.Validator = &Policy{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *Policy) ValidateCreate() (admission.Warnings, error) {
+	policylog.Info("Validate policy creation request", "name", r.Name)
+
+	return r.validateName()
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *Policy) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *Policy) ValidateDelete() (admission.Warnings, error) {
+	return nil, nil
+}
+
+// validate the policy name and namespace length
+func (r *Policy) validateName() (admission.Warnings, error) {
+	policylog.Info("Validating the policy name through a validating webhook")
+
+	// replicated policies don't need pass this validation
+	if _, ok := r.GetLabels()["policy.open-cluster-management.io/root-policy"]; ok {
+		return nil, nil
+	}
+
+	// 1 character for "."
+	if (utf8.RuneCountInString(r.Name) + utf8.RuneCountInString(r.Namespace)) > 62 {
+		return nil, errName
+	}
+
+	return nil, nil
+}

--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -2,16 +2,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    webhook-origin: governance-policy-propagator
   name: governance-policy-propagator
 spec:
   replicas: 1
   selector:
     matchLabels:
       name: governance-policy-propagator
+      webhook-origin: governance-policy-propagator
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: governance-policy-propagator
       labels:
         name: governance-policy-propagator
+        webhook-origin: governance-policy-propagator
     spec:
       serviceAccountName: governance-policy-propagator
       containers:
@@ -27,7 +33,14 @@ spec:
             - containerPort: 8383
               protocol: TCP
               name: http
+            - containerPort: 9443
+              protocol: TCP
+              name: webhook-http
           imagePullPolicy: Always
+          volumeMounts:
+          - mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: cert
+            readOnly: true
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -37,6 +50,11 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "governance-policy-propagator"
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: propagator-webhook-server-cert
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -231,16 +231,22 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    webhook-origin: governance-policy-propagator
   name: governance-policy-propagator
 spec:
   replicas: 1
   selector:
     matchLabels:
       name: governance-policy-propagator
+      webhook-origin: governance-policy-propagator
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: governance-policy-propagator
       labels:
         name: governance-policy-propagator
+        webhook-origin: governance-policy-propagator
     spec:
       containers:
       - args:
@@ -265,4 +271,16 @@ spec:
         - containerPort: 8383
           name: http
           protocol: TCP
+        - containerPort: 9443
+          name: webhook-http
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
       serviceAccountName: governance-policy-propagator
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: propagator-webhook-server-cert

--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: propagator-webhook-service
+  namespace: open-cluster-management
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    webhook-origin: governance-policy-propagator
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: propagator-webhook-serving-cert
+  namespace: open-cluster-management
+spec:
+  dnsNames:
+  - propagator-webhook-service.open-cluster-management.svc
+  - propagator-webhook-service.open-cluster-management.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: propagator-webhook-selfsigned-issuer
+  secretName: propagator-webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: propagator-webhook-selfsigned-issuer
+  namespace: open-cluster-management
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: open-cluster-management/propagator-webhook-serving-cert
+  name: propagator-webhook-validating-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: propagator-webhook-service
+      namespace: open-cluster-management
+      path: /validate-policy-open-cluster-management-io-v1-policy
+  failurePolicy: Ignore
+  name: policy.open-cluster-management.io.webhook
+  rules:
+  - apiGroups:
+    - policy.open-cluster-management.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - policies
+  sideEffects: None

--- a/main_test.go
+++ b/main_test.go
@@ -14,7 +14,10 @@ import (
 // TestRunMain wraps the main() function in order to build a test binary and collection coverage for
 // E2E/Integration tests. Controller CLI flags are also passed in here.
 func TestRunMain(t *testing.T) {
-	os.Args = append(os.Args, "--leader-elect=false")
+	os.Args = append(os.Args,
+		"--leader-elect=false",
+		"--enable-webhooks=false",
+	)
 
 	main()
 }

--- a/test/e2e/case17_policy_webhook_test.go
+++ b/test/e2e/case17_policy_webhook_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"context"
+	"unicode/utf8"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
+)
+
+const (
+	case17PolicyLongYaml       string = "../resources/case17_policy_webhook/case17_policy_long.yaml"
+	case17PolicyReplicatedYaml string = "../resources/case17_policy_webhook/" +
+		"case17_policy_replicate.yaml"
+	longNamesapce              string = "long-long-long-long-long-long-long"
+	case17PolicyReplicatedName string = "case17-test-policy-replicated-longlong"
+	errMsg                     string = `admission webhook "policy.open-cluster-management.io.webhook" denied the ` +
+		`request: the combined length of the policy namespace and name <namespace>.<name> ` +
+		`cannot exceed 63 characters`
+)
+
+var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
+	BeforeAll(func() {
+		_, err := utils.KubectlWithOutput("create",
+			"ns", longNamesapce,
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+	AfterAll(func() {
+		// cleanup
+		_, err := utils.KubectlWithOutput("delete",
+			"ns", longNamesapce,
+			"--ignore-not-found",
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		_, err = utils.KubectlWithOutput("delete",
+			"policy", case17PolicyReplicatedName,
+			"-n", testNamespace,
+			"--ignore-not-found",
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+	Describe("Test name + namespace over 63", func() {
+		It("Should the error message is presented", func() {
+			output, err := utils.KubectlWithOutput("apply",
+				"-f", case17PolicyLongYaml,
+				"-n", longNamesapce)
+			Expect(err).Should(HaveOccurred())
+			Expect(output).Should(ContainSubstring(errMsg))
+		})
+		It("Should replicated policy should not be validated", func() {
+			_, err := utils.KubectlWithOutput("apply",
+				"-f", case17PolicyReplicatedYaml,
+				"-n", testNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+			plr := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementRule, case17PolicyReplicatedName+"-plr",
+				testNamespace, true, defaultTimeoutSeconds,
+			)
+			plr.Object["status"] = utils.GeneratePlrStatus("managed1")
+			_, err = clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+				context.TODO(), plr, metav1.UpdateOptions{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Replicated policy name and cluster namespace should be over 63 character")
+			Expect(utf8.RuneCountInString("managed1." + testNamespace +
+				"." + case17PolicyReplicatedName)).Should(BeNumerically(">", 63))
+
+			By("Replicated policy should be created")
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy, testNamespace+"."+case17PolicyReplicatedName,
+				"managed1", true, defaultTimeoutSeconds,
+			)
+			Expect(plc).ToNot(BeNil())
+		})
+	})
+})

--- a/test/resources/case17_policy_webhook/case17_policy_long.yaml
+++ b/test/resources/case17_policy_webhook/case17_policy_long.yaml
@@ -1,0 +1,45 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case17-test-policy-long-long-long
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case17-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case17-test-policy-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: case17-test-policy-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: case17-test-policy
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: case17-test-policy-plr
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      []

--- a/test/resources/case17_policy_webhook/case17_policy_replicate.yaml
+++ b/test/resources/case17_policy_webhook/case17_policy_replicate.yaml
@@ -1,0 +1,45 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case17-test-policy-replicated-longlong
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case17-test-policy-replicated-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case17-test-policy-replicated-longlong-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: case17-test-policy-replicated-longlong-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: case17-test-policy-replicated-longlong
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: case17-test-policy-replicated-longlong-plr
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      []


### PR DESCRIPTION
The 63-character limit validation for policy name is not working while creating a Policy via CLI.
Policy creation - Policy name + namespace name can’t go longer than 63 From CLI, it possible to create a policy with a name like “policy-check-setupjob-setupjob-operator-installer” with no issue; but, while wanting to edit it, we can’t.
Getting this error: “The combined length of namespace and policy name (namespaceName.policyName) should not exceed 63 characters (see attached screenshot)
Ref: https://issues.redhat.com/browse/ACM-3558

- Resolve `makefile` conflict issue

Signed-off-by: Yi Rae Kim [yikim@redhat.com](mailto:yikim@redhat.com)
(cherry-picked from commit c93f938892c18f3fe84655246ee1a92a963ad62e)