### PR TITLE
Run PolicyAutomation tests separately in CI

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -19,27 +19,15 @@ defaults:
     working-directory: governance-policy-propagator
 
 jobs:
-  kind-tests:
+  unit-tests:
     runs-on: ubuntu-latest
-    env:
-      REGISTRY: localhost:5000
-    strategy:
-      fail-fast: false
-      matrix:
-        # Run tests on minimum and newest supported OCP Kubernetes
-        # The "minimum" tag is set in the Makefile
-        # KinD tags: https://hub.docker.com/r/kindest/node/tags
-        kind:
-          - 'minimum'
-          - 'latest'
-    name: KinD tests
+    name: Unit Tests
     steps:
     - name: Checkout Governance Policy Propagator
       uses: actions/checkout@v3
       with:
         path: governance-policy-propagator
-        fetch-depth: 0 # Fetch all history for all tags and branches
-
+    
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
@@ -64,6 +52,38 @@ jobs:
       run: |
         make test
 
+    - name: Unit Test Coverage
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        make test-coverage
+    
+    - name: Upload Unit Test Coverage
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage_unit
+        path: governance-policy-propagator/coverage_unit.out
+
+  kind-tests:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: localhost:5000
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run tests on minimum and newest supported OCP Kubernetes
+        # The "minimum" tag is set in the Makefile
+        # KinD tags: https://hub.docker.com/r/kindest/node/tags
+        kind:
+          - 'minimum'
+          - 'latest'
+    name: KinD tests
+    steps:
+    - name: Checkout Governance Policy Propagator
+      uses: actions/checkout@v3
+      with:
+        path: governance-policy-propagator
+
     - name: Create K8s KinD Cluster - ${{ matrix.kind }}
       env:
         KIND_VERSION: ${{ matrix.kind }}
@@ -75,38 +95,24 @@ jobs:
         export GOPATH=$(go env GOPATH)
         make e2e-test-coverage
 
+    - name: Upload E2E Test Coverage
+      if: ${{ github.event_name == 'pull_request' && matrix.kind == 'latest'}}
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage_e2e
+        path: governance-policy-propagator/coverage_e2e.out
+
     - name: E2E Tests for Compliance Events API
       run: |
         make postgres
         make e2e-test-coverage-compliance-events-api
 
-    - name: Test Coverage and Report Generation
-      run: |
-        make test-coverage | tee report_unit.json
-        make coverage-verify
-        make gosec-scan
-        cat gosec.json
-
-    - name: Store the GitHub triggering event for the sonarcloud workflow
-      if: |
-        matrix.kind == 'latest' &&
-        github.repository_owner == 'stolostron'
-      run: |
-        cat <<EOF > event.json
-        ${{ toJSON(github.event) }}
-        EOF
-
-    - name: Upload artifacts for the sonarcloud workflow
-      if: |
-        matrix.kind == 'latest' &&
-        github.repository_owner == 'stolostron'
+    - name: Upload Compliance Events API Test Coverage
+      if: ${{ github.event_name == 'pull_request' && matrix.kind == 'latest'}}
       uses: actions/upload-artifact@v3
       with:
-        name: artifacts
-        path: |
-          governance-policy-propagator/coverage*.out
-          governance-policy-propagator/event.json
-          governance-policy-propagator/gosec.json
+        name: coverage_e2e_compliance_events_api
+        path: governance-policy-propagator/coverage_e2e_compliance_events_api.out
 
     - name: Debug
       if: ${{ failure() }}
@@ -124,3 +130,106 @@ jobs:
       if: ${{ always() }}
       run: |
         make kind-delete-cluster
+
+  policyautomation-tests:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: localhost:5000
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run tests on minimum and newest supported OCP Kubernetes
+        # The "minimum" tag is set in the Makefile
+        # KinD tags: https://hub.docker.com/r/kindest/node/tags
+        kind:
+          - 'minimum'
+          - 'latest'
+    name: PolicyAutomation tests
+    steps:
+    - name: Checkout Governance Policy Propagator
+      uses: actions/checkout@v3
+      with:
+        path: governance-policy-propagator
+
+    - name: Create K8s KinD Cluster - ${{ matrix.kind }}
+      env:
+        KIND_VERSION: ${{ matrix.kind }}
+      run: |
+        make kind-bootstrap-cluster-dev
+
+    - name: PolicyAutomation E2E Tests
+      run: |
+        export GOPATH=$(go env GOPATH)
+        make e2e-test-coverage-policyautomation
+
+    - name: Upload PolicyAutomation Test Coverage
+      if: ${{ github.event_name == 'pull_request' && matrix.kind == 'latest'}}
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage_e2e_policyautomation
+        path: governance-policy-propagator/coverage_e2e_policyautomation.out
+
+    - name: Debug
+      if: ${{ failure() }}
+      run: |
+        make e2e-debug
+
+    - name: Clean up cluster
+      if: ${{ always() }}
+      run: |
+        make kind-delete-cluster
+
+  coveage-verification:
+    defaults:
+      run:
+        working-directory: '.'
+    runs-on: ubuntu-latest
+    name: Test Coverage Verification
+    if: ${{ github.event_name == 'pull_request' }}
+    needs: [unit-tests, kind-tests, policyautomation-tests]
+
+    steps:
+    - name: Checkout Governance Policy Propagator
+      uses: actions/checkout@v3
+
+    - name: Download Unit Coverage Result
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage_unit
+    
+    - name: Download E2E Coverage Result
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage_e2e
+
+    - name: Download Compliance Events Coverage Result
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage_e2e_compliance_events_api
+
+    - name: Download PolicyAutomation Coverage Result
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage_e2e_policyautomation
+    
+    - name: Test Coverage Verification
+      run: |
+        make coverage-verify
+    
+    - name: Prepare additional artifacts for the sonarcloud workflow
+      run: |
+        make gosec-scan
+        cat gosec.json
+        cat <<EOF > event.json
+        ${{ toJSON(github.event) }}
+        EOF
+    
+    - name: Upload artifacts for the sonarcloud workflow
+      if: github.repository_owner == 'stolostron'
+      uses: actions/upload-artifact@v3
+      with:
+        name: artifacts
+        path: |
+          ./coverage*.out
+          ./event.json
+          ./gosec.json

--- a/Makefile
+++ b/Makefile
@@ -317,36 +317,49 @@ install-resources:
 e2e-dependencies:
 	$(call go-get-tool,github.com/onsi/ginkgo/v2/ginkgo@$(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print $$2}' go.mod))
 
+E2E_LABEL_FILTER = --label-filter="!webhook && !compliance-events-api && !policyautomation"
 .PHONY: e2e-test
 e2e-test: e2e-dependencies
-	$(GINKGO) -v --fail-fast $(E2E_TEST_ARGS) --label-filter="!webhook && !compliance-events-api" test/e2e
+	$(GINKGO) -v --fail-fast $(E2E_TEST_ARGS) $(E2E_LABEL_FILTER) test/e2e
 
-.PHONY: e2e-test-coverage
-e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --output-dir=.
-e2e-test-coverage: e2e-run-instrumented e2e-test e2e-stop-instrumented
+.PHONY: e2e-test-webhook
+e2e-test-webhook: E2E_LABEL_FILTER = --label-filter="webhook"
+e2e-test-webhook: e2e-test
+
+.PHONY: e2e-test-compliance-events-api
+e2e-test-compliance-events-api: E2E_LABEL_FILTER = --label-filter="compliance-events-api"
+e2e-test-compliance-events-api: e2e-test
+
+.PHONY: e2e-test-coverage-compliance-events-api
+e2e-test-coverage-compliance-events-api: E2E_TEST_ARGS = --json-report=report_e2e_compliance_events_api.json --covermode=atomic --coverpkg=open-cluster-management.io/governance-policy-propagator/controllers/complianceeventsapi --coverprofile=coverage_e2e_compliance_events_api.out --output-dir=.
+e2e-test-coverage-compliance-events-api: e2e-test-compliance-events-api
+
+.PHONY: e2e-test-policyautomation
+e2e-test-policyautomation: E2E_LABEL_FILTER = --label-filter="policyautomation"
+e2e-test-policyautomation: e2e-test
 
 .PHONY: e2e-build-instrumented
 e2e-build-instrumented:
 	go test -covermode=atomic -coverpkg=$(shell cat go.mod | head -1 | cut -d ' ' -f 2)/... -c -tags e2e ./ -o build/_output/bin/$(IMG)-instrumented
 
+TEST_COVERAGE_OUT = coverage_e2e.out
 .PHONY: e2e-run-instrumented
 e2e-run-instrumented: e2e-build-instrumented
-	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=coverage_e2e.out &>build/_output/controller.log &
+	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=$(TEST_COVERAGE_OUT) &>build/_output/controller.log &
 
 .PHONY: e2e-stop-instrumented
 e2e-stop-instrumented:
 	ps -ef | grep '$(IMG)' | grep -v grep | awk '{print $$2}' | xargs kill
 
-e2e-test-webhook:
-	$(GINKGO) -v --fail-fast --label-filter="webhook" test/e2e 
+.PHONY: e2e-test-coverage
+e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --output-dir=.
+e2e-test-coverage: e2e-run-instrumented e2e-test e2e-stop-instrumented
 
-.PHONY: e2e-test-compliance-events-api
-e2e-test-compliance-events-api:
-	$(GINKGO) -v --fail-fast $(E2E_TEST_ARGS) --label-filter="compliance-events-api" test/e2e
-
-.PHONY: e2e-test-coverage-compliance-events-api
-e2e-test-coverage-compliance-events-api: E2E_TEST_ARGS = --json-report=report_e2e_compliance_events_api.json --covermode=atomic --coverpkg=open-cluster-management.io/governance-policy-propagator/controllers/complianceeventsapi --coverprofile=coverage_e2e_compliance_events_api.out --output-dir=.
-e2e-test-coverage-compliance-events-api: e2e-test-compliance-events-api
+.PHONY: e2e-test-coverage-policyautomation
+e2e-test-coverage-policyautomation: E2E_TEST_ARGS = --json-report=report_e2e_policyautomation.json --output-dir=.
+e2e-test-coverage-policyautomation: E2E_LABEL_FILTER = --label-filter="policyautomation"
+e2e-test-coverage-policyautomation: TEST_COVERAGE_OUT = coverage_e2e_policyautomation.out
+e2e-test-coverage-policyautomation: e2e-test-coverage
 
 .PHONY: e2e-debug
 e2e-debug:

--- a/test/e2e/case5_policy_automation_test.go
+++ b/test/e2e/case5_policy_automation_test.go
@@ -27,7 +27,7 @@ const (
 
 const automationName string = "create-service.now-ticket"
 
-var _ = Describe("Test policy automation", Ordered, func() {
+var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, func() {
 	ansiblelistlen := 0
 	// Use this only when target_clusters managed1 managed2 managed3
 	getLastAnsiblejob := func() *unstructured.Unstructured {


### PR DESCRIPTION
The PolicyAutomation tests were taking about half of the total e2e test duration. This excludes those tests from the usual `make e2e-test` target, which will accelerate both the CI and local development. Those tests are now run in a separate (concurrent) GH job in the CI workflow, and the test coverage information is merged in another new job.

This also combines the unit tests and linting tasks into one job, which means that a linting or formatting error will not prevent the e2e tests from running.

Refs:
 - https://issues.redhat.com/browse/ACM-8239

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>
(cherry picked from commit db0c8dd8f82fa9973c19b643d9fd1b41be86e1eb)

Closes https://github.com/stolostron/governance-policy-propagator/issues/488