### PR TITLE
[release-2.9] Manual cherry-pick: Fix status update with faulty PlacementBinding

### DIFF
--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -179,8 +179,11 @@ func HasValidPlacementRef(pb *policiesv1.PlacementBinding) bool {
 func GetDecisions(
 	ctx context.Context, c client.Client, pb *policiesv1.PlacementBinding,
 ) ([]appsv1.PlacementDecision, error) {
+	// If the PlacementRef is invalid, log and return. (This is not recoverable.)
 	if !HasValidPlacementRef(pb) {
-		return nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Namespace, pb.Name)
+		log.Info(fmt.Sprintf("PlacementBinding %s/%s placementRef is not valid. Ignoring.", pb.Namespace, pb.Name))
+
+		return nil, nil
 	}
 
 	refNN := types.NamespacedName{

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -180,7 +180,7 @@ func GetDecisions(
 	ctx context.Context, c client.Client, pb *policiesv1.PlacementBinding,
 ) ([]appsv1.PlacementDecision, error) {
 	if !HasValidPlacementRef(pb) {
-		return nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Name, pb.Namespace)
+		return nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Namespace, pb.Name)
 	}
 
 	refNN := types.NamespacedName{
@@ -234,7 +234,7 @@ func GetDecisions(
 		return plr.Status.Decisions, nil
 	}
 
-	return nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Name, pb.Namespace)
+	return nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Namespace, pb.Name)
 }
 
 func ParseRootPolicyLabel(rootPlc string) (name, namespace string, err error) {

--- a/controllers/common/common_status_update.go
+++ b/controllers/common/common_status_update.go
@@ -69,10 +69,6 @@ func RootStatusUpdate(ctx context.Context, c client.Client, rootPolicy *policies
 func GetPolicyPlacementDecisions(ctx context.Context, c client.Client,
 	instance *policiesv1.Policy, pb *policiesv1.PlacementBinding,
 ) (decisions []appsv1.PlacementDecision, placements []*policiesv1.Placement, err error) {
-	if !HasValidPlacementRef(pb) {
-		return nil, nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Namespace, pb.Name)
-	}
-
 	policySubjectFound := false
 	policySetSubjects := make(map[string]struct{}) // a set, to prevent duplicates
 
@@ -106,6 +102,13 @@ func GetPolicyPlacementDecisions(ctx context.Context, c client.Client,
 
 	if len(placements) == 0 {
 		// None of the subjects in the PlacementBinding were relevant to this Policy.
+		return nil, nil, nil
+	}
+
+	// If the PlacementRef is invalid, log and return. (This is not recoverable.)
+	if !HasValidPlacementRef(pb) {
+		log.Info(fmt.Sprintf("Placement binding %s/%s placementRef is not valid. Ignoring.", pb.Namespace, pb.Name))
+
 		return nil, nil, nil
 	}
 

--- a/controllers/common/common_status_update.go
+++ b/controllers/common/common_status_update.go
@@ -70,7 +70,7 @@ func GetPolicyPlacementDecisions(ctx context.Context, c client.Client,
 	instance *policiesv1.Policy, pb *policiesv1.PlacementBinding,
 ) (decisions []appsv1.PlacementDecision, placements []*policiesv1.Placement, err error) {
 	if !HasValidPlacementRef(pb) {
-		return nil, nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Name, pb.Namespace)
+		return nil, nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Namespace, pb.Name)
 	}
 
 	policySubjectFound := false

--- a/test/resources/case2_aggregation/faulty-placementbinding.yaml
+++ b/test/resources/case2_aggregation/faulty-placementbinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case2-faulty-placementbinding
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: PlacementRule
+  name: case2-test-policy-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: rando-policy


### PR DESCRIPTION
Manual cherry-pick from:
- #566 

With a PlacementBinding containing an invalid placementRef, the propagator was returning an error and endlessly re-reconciling. This occurs even if the PlacementBinding was not bound to the Policy.

Also swaps the namespace and name in the message because it was non-standard.

ref: https://issues.redhat.com/browse/ACM-9930
