### PR TITLE
🙃 Sync from open-cluster-management-io/governance-policy-propagator: #231

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -125,6 +125,11 @@ jobs:
     - name: E2E Tests for Webhook
       run: |
         KUBECONFIG=${PWD}/kubeconfig_hub make e2e-test-webhook
+    
+    - name: Tests without PlacementRule
+      run: |
+        KUBECONFIG=${PWD}/kubeconfig_hub_e2e kubectl delete crd placementrules.apps.open-cluster-management.io
+        KUBECONFIG=${PWD}/kubeconfig_hub make e2e-test-non-placement-rule
 
     - name: Debug
       if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,10 @@ e2e-test-coverage-compliance-events-api: e2e-test-compliance-events-api
 e2e-test-policyautomation: E2E_LABEL_FILTER = --label-filter="policyautomation"
 e2e-test-policyautomation: e2e-test
 
+.PHONY: e2e-test-non-placement-rule
+e2e-test-non-placement-rule: E2E_LABEL_FILTER = --label-filter="non-placement-rule"
+e2e-test-non-placement-rule: e2e-test
+
 .PHONY: e2e-build-instrumented
 e2e-build-instrumented:
 	go test -covermode=atomic -coverpkg=$(shell cat go.mod | head -1 | cut -d ' ' -f 2)/... -c -tags e2e ./ -o build/_output/bin/$(IMG)-instrumented

--- a/test/e2e/case4_unexpected_policy_test.go
+++ b/test/e2e/case4_unexpected_policy_test.go
@@ -11,7 +11,7 @@ import (
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
-var _ = Describe("Test unexpect policy handling", func() {
+var _ = Describe("Test unexpect policy handling", Label("non-placement-rule"), func() {
 	const (
 		case4PolicyName string = "case4-test-policy"
 		case4PolicyYaml string = "../resources/case4_unexpected_policy/case4-test-policy.yaml"


### PR DESCRIPTION
Syncing the following PRs:
* open-cluster-management-io/governance-policy-propagator#232

(The PR included a change to a workflow which the app did not have permission to push.)

```
Add flag to disable PlacementRule watches

Some deployments will not want to install the PlacementRule CRD, since
it is an older API which may eventually be removed. This adds an
argument to the propagator which will disable all watches on
PlacementRules, allowing the controllers to run in those environments.

In addition, if the flag is not set, the controller will check for the
PlacementRule CRD on the cluster, and if not found, disable those
watches (which would otherwise fail and prevent the controller from
working).

Refs:
 - https://issues.redhat.com/browse/ACM-2609

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>
(cherry picked from commit 474fdc8eda15469a477eb9861461a94e86c35a0d)
```

Closes: https://github.com/stolostron/governance-policy-propagator/issues/792