### PR TITLE
[Manual Sync] Update go-template-utils to v6.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.2
-	github.com/stolostron/go-template-utils/v6 v6.1.0
-	github.com/stolostron/kubernetes-dependency-watches v0.9.0
+	github.com/stolostron/go-template-utils/v6 v6.1.1
+	github.com/stolostron/kubernetes-dependency-watches v0.9.1
 	github.com/stolostron/rbac-api-utils v0.0.0-20240404212618-7f57fc664256
 	k8s.io/api v0.29.5
 	k8s.io/apimachinery v0.29.5

--- a/go.sum
+++ b/go.sum
@@ -167,10 +167,10 @@ github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ai
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stolostron/go-log-utils v0.1.2 h1:7l1aJWvBqU2+DUyimcslT5SJpdygVY/clRDmX5sO29c=
 github.com/stolostron/go-log-utils v0.1.2/go.mod h1:8zrB8UJmp1rXhv3Ck9bBl5SpNfKk3SApeElbo96YRtQ=
-github.com/stolostron/go-template-utils/v6 v6.1.0 h1:+ExYotoV3o1D4WlTiCaYCRhVaeEDGZPw3hMattXXylg=
-github.com/stolostron/go-template-utils/v6 v6.1.0/go.mod h1:zf62ttS3TSKfIhk5MXksJx7dmVNwPheH+pesYxjCw8c=
-github.com/stolostron/kubernetes-dependency-watches v0.9.0 h1:ZOJDdpJ9vmD8RPoHKhyZNqgv6pvasUKT18F0xSwiY1g=
-github.com/stolostron/kubernetes-dependency-watches v0.9.0/go.mod h1:BpDgquBjEbNM9dQYlLndGBX+FoaXDUJQ6eR3j1NA+Kk=
+github.com/stolostron/go-template-utils/v6 v6.1.1 h1:Fm68U6vSSOihgiUYsRdI5P3Xj8APxZIJyeAvCH/39Sc=
+github.com/stolostron/go-template-utils/v6 v6.1.1/go.mod h1:tMHdfS/X/Fn7lliavT3q/yK0oI0mvxp+g9qXXSReuk0=
+github.com/stolostron/kubernetes-dependency-watches v0.9.1 h1:54FSEdcE+3MECfmW7nvMToy0vBbufwCzXfEHty9G8Ho=
+github.com/stolostron/kubernetes-dependency-watches v0.9.1/go.mod h1:BpDgquBjEbNM9dQYlLndGBX+FoaXDUJQ6eR3j1NA+Kk=
 github.com/stolostron/multicloud-operators-subscription v1.2.4-0-20211122-7277a37.0.20240523030503-8db21b6fcbe9 h1:OUDwFT3m3zjhxP6tyWNHtuI8DLG6pIm7B1JjmmxnRqw=
 github.com/stolostron/multicloud-operators-subscription v1.2.4-0-20211122-7277a37.0.20240523030503-8db21b6fcbe9/go.mod h1:8wBE7j1VXV/SnT0x5Mws6oqOnoYmfXi5Xjrh9w5IzGI=
 github.com/stolostron/rbac-api-utils v0.0.0-20240404212618-7f57fc664256 h1:BeTUZoAkKzPKSH0sG4a9PaakKHuJ0h9Cks9joBn3Ns8=


### PR DESCRIPTION
Closes #812 