### PR TITLE
Issue 995 - deprecated webhook.Validator

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -197,7 +197,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: stable
 
     - name: Download Unit Coverage Result
       uses: actions/download-artifact@v4


### PR DESCRIPTION
- Fix usage of deprecated webhook.Validator interface
- Set Go version for coverage to latest

Manual cherrypick
- https://github.com/open-cluster-management-io/governance-policy-propagator/pull/250

Closes #995 