### PR TITLE
[release-2.11] chore: realign PolicyAutomation CRD

### DIFF
--- a/api/v1beta1/policyautomation_types.go
+++ b/api/v1beta1/policyautomation_types.go
@@ -68,7 +68,6 @@ type PolicyAutomationSpec struct {
 	// "noncompliant".
 	//
 	// +kubebuilder:validation:Enum={noncompliant}
-	// +kubebuilder:validation:Required
 	EventHook string `json:"eventHook,omitempty"`
 
 	// RescanAfter is reserved for future use and should not be set.

--- a/deploy/crds/policy.open-cluster-management.io_policyautomations.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_policyautomations.yaml
@@ -116,7 +116,6 @@ spec:
                 type: string
             required:
             - automationDef
-            - eventHook
             - mode
             - policyRef
             type: object


### PR DESCRIPTION
Prior to the `controller-gen` bump, `eventHook` was not required.

Followup to:
- #1234