### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/build/Dockerfile.art
+++ b/build/Dockerfile.art
@@ -1,0 +1,43 @@
+ARG ACM_VERSION=${ACM_VERSION}
+
+# Stage 1: Use image builder to build the target binaries
+# Copyright Contributors to the Open Cluster Management project
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+ENV COMPONENT=governance-policy-propagator
+ENV REPO_PATH=/go/src/github.com/stolostron/${COMPONENT}
+WORKDIR ${REPO_PATH}
+COPY . .
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make build
+
+# Stage 2: Copy the binaries from the image builder to the base image
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+ARG ACM_VERSION
+
+ENV COMPONENT=governance-policy-propagator
+ENV REPO_PATH=/go/src/github.com/stolostron/${COMPONENT}
+ENV OPERATOR=/usr/local/bin/${COMPONENT} \
+    USER_UID=1001 \
+    USER_NAME=${COMPONENT}
+
+# install operator binary
+COPY --from=builder ${REPO_PATH}/build/_output/bin/${COMPONENT} ${OPERATOR}
+
+COPY --from=builder ${REPO_PATH}/build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}
+
+LABEL name="rhacm2/governance-policy-propagator-rhel9"
+LABEL summary="Propagate Policies to managed cluster namespaces"
+LABEL description="Propagate Policies from user namespaces to managed cluster namespaces as defined by the PlacementBinding and bound Placement."
+LABEL io.k8s.display-name="Governance policy propagator"
+LABEL io.k8s.description="Propagate Policies from user namespaces to managed cluster namespaces as defined by the PlacementBinding and bound Placement."
+LABEL com.redhat.component="acm-governance-policy-propagator-container"
+LABEL io.openshift.tags="data,images"
+LABEL url="https://github.com/stolostron/governance-policy-propagator"
+LABEL cpe="cpe:/a:redhat:acm:${ACM_VERSION}::el9"


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)