### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -9,7 +9,7 @@ ENV COMPONENT=governance-policy-propagator
 ENV REPO_PATH=/go/src/github.com/stolostron/${COMPONENT}
 WORKDIR ${REPO_PATH}
 COPY . .
-RUN make build
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make build
 
 # Stage 2: Copy the binaries from the image builder to the base image
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
Add CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to go build, make, and promu build lines for FIPS compliance.

JIRA: HYPBLD-847