### PR TITLE
Sync ocm-io 366: Ignore encryption keys not in cluster namespaces

### DIFF
--- a/controllers/encryptionkeys/encryptionkeys_controller.go
+++ b/controllers/encryptionkeys/encryptionkeys_controller.go
@@ -78,9 +78,22 @@ func (r *EncryptionKeysReconciler) Reconcile(ctx context.Context, request ctrl.R
 		return reconcile.Result{}, nil
 	}
 
+	inClusterNamespace, err := common.IsInClusterNamespace(ctx, r.Client, request.Namespace)
+	if err != nil {
+		log.Error(err, "Unable to determine if this secret should be reconciled, re-queueing")
+
+		return reconcile.Result{}, err
+	}
+
+	if !inClusterNamespace {
+		log.Info("Got a reconciliation request for a Secret not in a managed cluster namespace - ignoring.")
+
+		return reconcile.Result{}, nil
+	}
+
 	secret := &corev1.Secret{}
 
-	err := r.Get(ctx, request.NamespacedName, secret)
+	err = r.Get(ctx, request.NamespacedName, secret)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			log.Info("The Secret was not found on the server. Doing nothing.")

--- a/controllers/encryptionkeys/encryptionkeys_controller_test.go
+++ b/controllers/encryptionkeys/encryptionkeys_controller_test.go
@@ -20,6 +20,7 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -195,8 +196,14 @@ func getReconciler(encryptionSecret *corev1.Secret) *EncryptionKeysReconciler {
 	Expect(err).ToNot(HaveOccurred())
 	err = v1.AddToScheme(scheme)
 	Expect(err).ToNot(HaveOccurred())
+	err = clusterv1.Install(scheme)
+	Expect(err).ToNot(HaveOccurred())
 
 	builder := fake.NewClientBuilder().WithObjects(policies...).WithScheme(scheme)
+
+	builder = builder.WithObjects(&clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+	})
 
 	if encryptionSecret != nil {
 		builder = builder.WithObjects(encryptionSecret)

--- a/test/e2e/case12_encryptionkeys_controller_test.go
+++ b/test/e2e/case12_encryptionkeys_controller_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -18,7 +19,7 @@ import (
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
-var _ = Describe("Test policy encryption key rotation", func() {
+var _ = Describe("Test policy encryption key rotation", Ordered, func() {
 	key := bytes.Repeat([]byte{byte('A')}, 256/8)
 	keyB64 := base64.StdEncoding.EncodeToString(key)
 	previousKey := bytes.Repeat([]byte{byte('B')}, 256/8)
@@ -167,17 +168,47 @@ var _ = Describe("Test policy encryption key rotation", func() {
 		Expect(policy.GetAnnotations()[TriggerUpdateAnnotation]).Should(Equal(""))
 	})
 
-	It("clean up", func(ctx SpecContext) {
-		err := clientHub.CoreV1().Secrets("managed1").Delete(
-			ctx, EncryptionKeySecret, metav1.DeleteOptions{},
-		)
+	It("should not rotate a secret in a non-cluster namespace", func(ctx SpecContext) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      EncryptionKeySecret,
+				Namespace: "default",
+			},
+			Data: map[string][]byte{"key": key},
+		}
+		_, err := clientHub.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
 		Expect(err).ShouldNot(HaveOccurred())
+
+		Consistently(func() any {
+			secret := utils.GetWithTimeout(clientHubDynamic, gvrSecret, EncryptionKeySecret,
+				"default", true, defaultTimeoutSeconds)
+
+			data, ok := secret.Object["data"].(map[string]any)
+			if !ok {
+				return ""
+			}
+
+			return data["key"].(string)
+		}, "10s", 1).Should(Equal(keyB64))
+	})
+
+	AfterAll(func(ctx SpecContext) {
+		err := clientHub.CoreV1().Secrets("managed1").Delete(ctx, EncryptionKeySecret, metav1.DeleteOptions{})
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).ShouldNot(HaveOccurred())
+		}
+
+		err = clientHub.CoreV1().Secrets("default").Delete(ctx, EncryptionKeySecret, metav1.DeleteOptions{})
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).ShouldNot(HaveOccurred())
+		}
 
 		for _, policyName := range []string{"policy-one", "policy-two"} {
 			err = clientHubDynamic.Resource(gvrPolicy).Namespace(testNamespace).Delete(
-				ctx, policyName, metav1.DeleteOptions{},
-			)
-			Expect(err).ShouldNot(HaveOccurred())
+				ctx, policyName, metav1.DeleteOptions{})
+			if !k8serrors.IsNotFound(err) {
+				Expect(err).ShouldNot(HaveOccurred())
+			}
 		}
 	})
 })


### PR DESCRIPTION
Previously, in hosted-mode deployments where the framework-addon pod for a managed cluster was deployed on the hub cluster (but was not managing `local-cluster`), the copied encryption key would be immediately rotated by the propagator. Usually a policy controller using that key would fallback to using the "previousKey" and not have any obvious issues, but sometimes it would decrypt noise which it attempted to apply on the cluster, which is almost guaranteed to cause a parsing error and fail.

It's possible users may have noticed this behavior from the propagator by manually creating other Secrets on the hub, named "policy-encryption-key".

Now, the encryptionkeys controller checks that the Secret being reconciled is in a managed cluster namespace, and ignores it if it isn't.

Refs:
 - https://issues.redhat.com/browse/ACM-42671

(cherry picked from commit fb23ed11c3a1dd423643c0ade75b9f5e06de66d5)

### Cherry-pick note
The "Fix gosec run error" commit was already fixed here separately.

Closes https://github.com/stolostron/governance-policy-propagator/issues/1441